### PR TITLE
feat: Add resizable window support

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,11 @@ module.exports = [
         exports: 'readonly',
         __dirname: 'readonly',
         __filename: 'readonly',
-        Buffer: 'readonly'
+        Buffer: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly'
       }
     },
     ...js.configs.recommended

--- a/src/main/constants/window.ts
+++ b/src/main/constants/window.ts
@@ -1,0 +1,11 @@
+// ウィンドウサイズの定数定義
+export const WINDOW_SIZES = {
+  default: {
+    width: 600,
+    height: 560,
+  },
+  minimum: {
+    width: 500,
+    height: 400,
+  },
+} as const;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from 'electron';
 import { join } from 'path';
 import { registerIpcHandlers } from './ipc/handlers';
 import { settingsStore } from './store/settings';
+import { WINDOW_SIZES } from './constants/window';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -22,22 +23,18 @@ if (process.platform === 'darwin' && app.dock) {
 }
 
 function createWindow() {
-  // デフォルトサイズ
-  const defaultWidth = 600;
-  const defaultHeight = 560;
-
   // 設定から最前面表示とウィンドウサイズを取得
   const settings = settingsStore.get();
   const savedBounds = settings.windowBounds;
 
   mainWindow = new BrowserWindow({
     title: 'EPUB Image Extractor',
-    width: savedBounds?.width || defaultWidth,
-    height: savedBounds?.height || defaultHeight,
+    width: savedBounds?.width || WINDOW_SIZES.default.width,
+    height: savedBounds?.height || WINDOW_SIZES.default.height,
     x: savedBounds?.x,
     y: savedBounds?.y,
-    minWidth: 500, // 最小幅
-    minHeight: 400, // 最小高さ
+    minWidth: WINDOW_SIZES.minimum.width,
+    minHeight: WINDOW_SIZES.minimum.height,
     resizable: true, // リサイズ可能に設定
     alwaysOnTop: settings.alwaysOnTop,
     icon:

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { settingsStore } from '../store/settings';
 import { extractEpubsFromZip, cleanupTempFiles, isZipFile } from '../utils/zipHandler';
+import { WINDOW_SIZES } from '../constants/window';
 
 // 出力ディレクトリ選択
 export function registerIpcHandlers(mainWindow: BrowserWindow) {
@@ -123,9 +124,7 @@ export function registerIpcHandlers(mainWindow: BrowserWindow) {
     
     // デフォルトサイズに即座にリサイズ
     if (mainWindow) {
-      const defaultWidth = 600;
-      const defaultHeight = 560;
-      mainWindow.setSize(defaultWidth, defaultHeight);
+      mainWindow.setSize(WINDOW_SIZES.default.width, WINDOW_SIZES.default.height);
       mainWindow.center(); // 画面中央に配置
     }
     

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -120,6 +120,15 @@ export function registerIpcHandlers(mainWindow: BrowserWindow) {
   // ウィンドウサイズのクリア
   ipcMain.handle('settings:clearWindowBounds', async () => {
     settingsStore.setWindowBounds(undefined);
+    
+    // デフォルトサイズに即座にリサイズ
+    if (mainWindow) {
+      const defaultWidth = 600;
+      const defaultHeight = 560;
+      mainWindow.setSize(defaultWidth, defaultHeight);
+      mainWindow.center(); // 画面中央に配置
+    }
+    
     return { success: true };
   });
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -109,7 +109,18 @@ export function registerIpcHandlers(mainWindow: BrowserWindow) {
   // 設定のリセット
   ipcMain.handle('settings:reset', async () => {
     settingsStore.resetToDefaults();
-    return settingsStore.get();
+    const defaultSettings = settingsStore.get();
+    // デフォルトのalwaysOnTopを即座に適用
+    if (mainWindow) {
+      mainWindow.setAlwaysOnTop(defaultSettings.alwaysOnTop);
+    }
+    return defaultSettings;
+  });
+
+  // ウィンドウサイズのクリア
+  ipcMain.handle('settings:clearWindowBounds', async () => {
+    settingsStore.setWindowBounds(undefined);
+    return { success: true };
   });
 
   // フォルダを開く

--- a/src/main/store/settings.ts
+++ b/src/main/store/settings.ts
@@ -73,8 +73,7 @@ export const settingsStore = {
   setWindowBounds: (bounds: Settings['windowBounds']) => {
     if (bounds === undefined) {
       // windowBoundsを削除（デフォルト値に戻す）
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      store.set('windowBounds', undefined as any);
+      store.delete('windowBounds');
     } else {
       store.set('windowBounds', bounds);
     }

--- a/src/main/store/settings.ts
+++ b/src/main/store/settings.ts
@@ -8,6 +8,12 @@ interface Settings {
   alwaysOnTop: boolean;
   includeOriginalFilename: boolean; // 元のファイル名を含めるか
   includePageSpread: boolean; // 左右情報を含めるか
+  windowBounds?: { // ウィンドウのサイズと位置
+    width: number;
+    height: number;
+    x?: number;
+    y?: number;
+  };
 }
 
 const defaults: Settings = {
@@ -36,6 +42,7 @@ export const settingsStore = {
       alwaysOnTop: store.get('alwaysOnTop'),
       includeOriginalFilename: store.get('includeOriginalFilename'),
       includePageSpread: store.get('includePageSpread'),
+      windowBounds: store.get('windowBounds'),
     };
   },
 
@@ -57,5 +64,13 @@ export const settingsStore = {
 
   resetToDefaults: (): void => {
     store.clear();
+  },
+
+  getWindowBounds: () => {
+    return store.get('windowBounds');
+  },
+
+  setWindowBounds: (bounds: Settings['windowBounds']) => {
+    store.set('windowBounds', bounds);
   },
 };

--- a/src/main/store/settings.ts
+++ b/src/main/store/settings.ts
@@ -71,6 +71,12 @@ export const settingsStore = {
   },
 
   setWindowBounds: (bounds: Settings['windowBounds']) => {
-    store.set('windowBounds', bounds);
+    if (bounds === undefined) {
+      // windowBoundsを削除（デフォルト値に戻す）
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      store.set('windowBounds', undefined as any);
+    } else {
+      store.set('windowBounds', bounds);
+    }
   },
 };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,7 @@ const electronAPI = {
   getSettings: () => ipcRenderer.invoke('settings:get'),
   saveSettings: (settings: Settings) => ipcRenderer.invoke('settings:save', settings),
   resetSettings: () => ipcRenderer.invoke('settings:reset'),
+  clearWindowBounds: () => ipcRenderer.invoke('settings:clearWindowBounds'),
   openFolder: (path: string) => ipcRenderer.invoke('file:openFolder', path),
 };
 

--- a/src/renderer/components/SettingsWindow.css
+++ b/src/renderer/components/SettingsWindow.css
@@ -19,6 +19,7 @@
   box-shadow: var(--shadow-2xl);
   width: 90%;
   max-width: 600px;
+  min-width: 480px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -190,6 +191,8 @@
   border-top: 1px solid var(--color-gray-200);
   background: linear-gradient(135deg, var(--color-gray-50) 0%, var(--color-white) 100%);
   border-radius: 0 0 var(--radius-2xl) var(--radius-2xl);
+  flex-wrap: wrap;
+  gap: var(--space-3);
 }
 
 .reset-button {
@@ -202,6 +205,7 @@
   transition: all var(--transition-fast);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  white-space: nowrap;
 }
 
 .reset-button:hover {
@@ -226,6 +230,7 @@
   font-weight: var(--font-weight-medium);
   transition: all var(--transition-fast);
   min-width: 100px;
+  white-space: nowrap;
 }
 
 .cancel-button {
@@ -258,4 +263,30 @@
   cursor: not-allowed;
   transform: none;
   box-shadow: var(--shadow-sm);
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 520px) {
+  .settings-window {
+    min-width: 95%;
+  }
+  
+  .settings-footer {
+    justify-content: center;
+  }
+  
+  .footer-buttons {
+    flex: 1;
+    justify-content: flex-end;
+  }
+  
+  .reset-button {
+    order: 1;
+    flex: 1;
+    text-align: center;
+  }
+  
+  .footer-buttons {
+    order: 2;
+  }
 }

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -28,6 +28,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
     includePageSpread: true,
   });
   const [isSaving, setIsSaving] = useState(false);
+  const [wasReset, setWasReset] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -41,6 +42,8 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
           includePageSpread: loadedSettings.includePageSpread ?? true,
         });
       });
+      // ダイアログを開いたときにリセットフラグをクリア
+      setWasReset(false);
     }
   }, [isOpen]);
 
@@ -60,6 +63,12 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       }
 
       await window.electronAPI.saveSettings(settings);
+      
+      // リセット後の保存の場合、ウィンドウサイズもデフォルトに戻す
+      if (wasReset) {
+        await window.electronAPI.clearWindowBounds();
+      }
+      
       onClose();
     } catch (error) {
       console.error('設定の保存に失敗しました:', error);
@@ -77,6 +86,8 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       includeOriginalFilename: defaultSettings.includeOriginalFilename ?? true,
       includePageSpread: defaultSettings.includePageSpread ?? true,
     });
+    // リセットフラグを設定
+    setWasReset(true);
   };
 
   if (!isOpen) return null;

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -19,6 +19,7 @@ interface ElectronAPI {
   getSettings: () => Promise<import('@shared/types').Settings>;
   saveSettings: (settings: import('@shared/types').Settings) => Promise<{ success: boolean }>;
   resetSettings: () => Promise<import('@shared/types').Settings>;
+  clearWindowBounds: () => Promise<{ success: boolean }>;
   openFolder: (path: string) => Promise<{ success: boolean; error?: string }>;
 }
 


### PR DESCRIPTION
## Summary
- ウィンドウをリサイズ可能にし、サイズと位置を永続化する機能を追加
- ユーザビリティ向上のため、ウィンドウサイズをユーザーの好みに合わせられるように
- 設定画面のボタンテキストが改行される問題を修正
- 設定リセット時にウィンドウサイズもデフォルトに戻る機能
- ウィンドウサイズ定数の一元管理

## Changes
### 機能追加
- ウィンドウのリサイズを有効化（`resizable: true`）
- 最小サイズ制約を設定（幅500px、高さ400px）
- ウィンドウサイズと位置を設定ファイルに保存
- アプリ起動時に前回のサイズと位置を復元
- リサイズ・移動時の保存処理にデバウンス（500ms）を適用

### 設定ストアの拡張
- `windowBounds`プロパティを追加（width, height, x, y）
- getter/setterメソッドを追加
- setWindowBoundsでundefinedを処理（deleteメソッドを使用）

### ESLint設定の更新
- Node.jsのタイマー関数（setTimeout, clearTimeout等）をグローバルに追加

### 設定画面の修正
- すべてのボタンに `white-space: nowrap` を追加してテキスト改行を防止
- 設定ウィンドウに最小幅（480px）を設定
- 520px以下の画面でのレスポンシブレイアウトを追加
- フッターのレイアウトを改善（flex-wrap, gap）

### 設定リセット時の動作改善
- clearWindowBounds APIを追加
- 設定リセット後の保存時にウィンドウサイズもクリア
- 即座にデフォルトサイズ（600x560）にリサイズして画面中央に配置
- 次回起動時もデフォルトサイズで起動

### コードの改善
- ウィンドウサイズ定数を `src/main/constants/window.ts` に一元化
- ハードコードされた値を `WINDOW_SIZES` 定数に置き換え
- 重複した定義を排除し、保守性を向上

## UI/UXへの影響
- 既存のUIは既にレスポンシブ対応されているため、追加の修正は不要
- 最小サイズ制約により、UIが崩れることを防止
- 設定画面のボタンが狭い画面でも正しく表示される
- 設定をデフォルトに戻した際、ウィンドウサイズも即座にリセットされる

## Test plan
- [x] `npm run lint` - ESLintエラーなし
- [x] `npm run typecheck` - TypeScriptコンパイルエラーなし
- [x] `npm test` - 全てのテストが成功
- [x] 開発環境での動作確認
  - [x] ウィンドウのリサイズが可能
  - [x] 最小サイズ以下にリサイズできない
  - [x] アプリ再起動時にサイズが復元される
  - [x] 設定画面のボタンテキストが改行されない
  - [x] 設定リセット後の保存でウィンドウサイズが即座にデフォルトに戻る
  - [x] 画面中央に配置される

🤖 Generated with [Claude Code](https://claude.ai/code)