### PR TITLE
fix: Prevent button text wrapping in settings window

### DIFF
--- a/src/renderer/components/SettingsWindow.css
+++ b/src/renderer/components/SettingsWindow.css
@@ -19,6 +19,7 @@
   box-shadow: var(--shadow-2xl);
   width: 90%;
   max-width: 600px;
+  min-width: 480px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -190,6 +191,8 @@
   border-top: 1px solid var(--color-gray-200);
   background: linear-gradient(135deg, var(--color-gray-50) 0%, var(--color-white) 100%);
   border-radius: 0 0 var(--radius-2xl) var(--radius-2xl);
+  flex-wrap: wrap;
+  gap: var(--space-3);
 }
 
 .reset-button {
@@ -202,6 +205,7 @@
   transition: all var(--transition-fast);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
+  white-space: nowrap;
 }
 
 .reset-button:hover {
@@ -226,6 +230,7 @@
   font-weight: var(--font-weight-medium);
   transition: all var(--transition-fast);
   min-width: 100px;
+  white-space: nowrap;
 }
 
 .cancel-button {
@@ -258,4 +263,30 @@
   cursor: not-allowed;
   transform: none;
   box-shadow: var(--shadow-sm);
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 520px) {
+  .settings-window {
+    min-width: 95%;
+  }
+  
+  .settings-footer {
+    justify-content: center;
+  }
+  
+  .footer-buttons {
+    flex: 1;
+    justify-content: flex-end;
+  }
+  
+  .reset-button {
+    order: 1;
+    flex: 1;
+    text-align: center;
+  }
+  
+  .footer-buttons {
+    order: 2;
+  }
 }


### PR DESCRIPTION
## Summary
- ウィンドウ幅を狭めた際に設定画面のボタン内でテキストが改行される問題を修正
- すべてのボタンに改行禁止設定を追加し、レスポンシブ対応を改善

## Changes
### CSS修正
1. **ボタンの改行防止**
   - すべてのボタン（リセット、キャンセル、保存）に `white-space: nowrap` を追加
   - ボタン内のテキストが改行されないように設定

2. **設定ウィンドウの最小幅設定**
   - `min-width: 480px` を追加して、ボタンが正しく配置される最小幅を確保

3. **レスポンシブ対応**
   - 520px以下の画面幅でのレイアウト調整
   - フッターのフレックスレイアウトに `flex-wrap` と `gap` を追加
   - 狭い画面でも適切に表示されるようにメディアクエリを追加

## Visual Changes
- ウィンドウを狭めてもボタンテキストが改行されない
- 非常に狭い画面（モバイルサイズ）でも適切なレイアウトを維持

## Test plan
- [x] `npm run lint` - ESLintエラーなし
- [x] `npm run build` - ビルドエラーなし
- [ ] ウィンドウを最小幅（500px）まで狭めてもボタンが正しく表示される
- [ ] 設定画面のすべてのボタンでテキストが改行されない

🤖 Generated with [Claude Code](https://claude.ai/code)