### PR TITLE
fix: Separate PR checks from release workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,59 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  quality-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24.x
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run ESLint
+      run: npm run lint
+    
+    - name: Run TypeScript check
+      run: npm run typecheck
+    
+    - name: Run unit tests
+      run: npm test
+    
+    - name: Run integration tests
+      run: npm run test:integration
+    
+    - name: Test build
+      run: npm run build
+    
+    - name: Comment PR
+      uses: actions/github-script@v7
+      if: always()
+      with:
+        script: |
+          const result = '${{ job.status }}';
+          const emoji = result === 'success' ? '✅' : '❌';
+          const message = result === 'success' 
+            ? 'All quality checks passed!' 
+            : 'Quality checks failed. Please review the logs.';
+          
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `${emoji} **PR Quality Check Result**: ${message}`
+          });

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,9 @@
 name: Release Please
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       release_type:
@@ -20,7 +23,32 @@ permissions:
   issues: write
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created || steps.release-explicit.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name || steps.release-explicit.outputs.tag_name }}
+    steps:
+      - name: Create Release PR (Auto)
+        uses: googleapis/release-please-action@v4
+        id: release
+        if: github.event.inputs.release_type == 'auto' || github.event.inputs.release_type == ''
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+      
+      - name: Create Release PR (Explicit)
+        uses: googleapis/release-please-action@v4
+        id: release-explicit
+        if: github.event.inputs.release_type != 'auto' && github.event.inputs.release_type != ''
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          release-as: ${{ github.event.inputs.release_type }}
+
   pre-release-checks:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -49,32 +77,8 @@ jobs:
     - name: Test build
       run: npm run build
 
-  release-please:
-    needs: pre-release-checks
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created || steps.release-explicit.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name || steps.release-explicit.outputs.tag_name }}
-    steps:
-      - name: Create Release PR (Auto)
-        uses: googleapis/release-please-action@v4
-        id: release
-        if: github.event.inputs.release_type == 'auto' || github.event.inputs.release_type == ''
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-      
-      - name: Create Release PR (Explicit)
-        uses: googleapis/release-please-action@v4
-        id: release-explicit
-        if: github.event.inputs.release_type != 'auto' && github.event.inputs.release_type != ''
-        with:
-          config-file: release-please-config.json
-          manifest-file: .release-please-manifest.json
-          release-as: ${{ github.event.inputs.release_type }}
-
   build-and-release:
-    needs: release-please
+    needs: [release-please, pre-release-checks]
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,39 +46,8 @@ jobs:
           manifest-file: .release-please-manifest.json
           release-as: ${{ github.event.inputs.release_type }}
 
-  pre-release-checks:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 24.x
-        cache: 'npm'
-    
-    - name: Install dependencies
-      run: npm ci
-    
-    - name: Run ESLint
-      run: npm run lint
-    
-    - name: Run TypeScript check
-      run: npm run typecheck
-    
-    - name: Run unit tests
-      run: npm test
-    
-    - name: Run integration tests
-      run: npm run test:integration
-    
-    - name: Test build
-      run: npm run build
-
   build-and-release:
-    needs: [release-please, pre-release-checks]
+    needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ${{ matrix.os }}
     

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -104,10 +104,17 @@ mainへのpush後、release-pleaseが自動的に既存のRelease PRを更新し
 mainブランチへのpush後、またはワークフローの手動実行後：
 
 1. **Pull Requestsページを確認**: 「chore(main): release X.X.X」というタイトルのPRを探す
-2. **内容を確認**:
+2. **自動品質チェック**: PRが作成されると自動的に以下が実行されます
+   - ESLintチェック
+   - TypeScriptコンパイルチェック
+   - ユニットテスト
+   - 統合テスト
+   - ビルドテスト
+3. **内容を確認**:
    - CHANGELOGの変更内容
    - package.jsonのバージョン
    - 含まれるコミット一覧
+   - 品質チェックの結果（すべて✅になっていることを確認）
 
 ### 3. 手動でのリリースバージョン指定（オプション）
 
@@ -127,15 +134,14 @@ mainブランチへのpush後、またはワークフローの手動実行後：
 
 **Release PR**をマージすると自動的に：
 
-1. **品質チェック**: ESLint、TypeScript、テスト、ビルドチェックを実行
-2. **タグ作成**: `v0.4.1`のようなタグが自動作成
-3. **GitHub Release作成**: リリースノートとともに公開
-4. **ビルド実行**: 各プラットフォーム向けにビルド
+1. **タグ作成**: `v0.4.1`のようなタグが自動作成
+2. **GitHub Release作成**: リリースノートとともに公開
+3. **ビルド実行**: 各プラットフォーム向けにビルド
    - macOS: `EPUB-Image-Extractor-{version}-arm64.dmg`
    - macOS: `EPUB-Image-Extractor-{version}-x64.dmg`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Setup.exe`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Portable.exe`
-5. **成果物アップロード**: ビルド成果物をGitHub Releaseに自動追加
+4. **成果物アップロード**: ビルド成果物をGitHub Releaseに自動追加
 
 ## 🛠 メンテナンス作業
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,12 +9,15 @@ EPUB Image Extractorは**release-please**を使用した自動リリース シ�
 ### 完全自動化されたリリースフロー
 
 1. **開発**: conventional commitsでコードを開発
-2. **プッシュ**: `main`ブランチにpush（リリースは自動実行されない）
-3. **手動リリース**: GitHub Actionsで「Release Please」ワークフローを手動実行
-4. **Release PR作成**: release-pleaseがRelease PRを作成
-5. **リリース**: Release PRをマージするとリリース実行
-6. **ビルド**: 自動的に各プラットフォーム用のビルド実行
-7. **配布**: GitHub Releaseにビルド成果物を自動アップロード
+2. **プッシュ**: `main`ブランチにpush
+3. **リリース準備**:
+   - 自動: mainへのpush時にrelease-pleaseが自動でRelease PRを作成/更新
+   - 手動: GitHub Actionsで「Release Please」ワークフローを手動実行してRelease PRを作成
+4. **Release PR確認**: 生成されたCHANGELOGとバージョンを確認
+5. **リリース実行**: Release PRをマージすると自動的にリリースが作成される
+6. **品質チェック**: リリース前に自動で品質チェックを実行
+7. **ビルド**: 各プラットフォーム用のビルドを自動実行
+8. **配布**: GitHub Releaseにビルド成果物を自動アップロード
 
 ### 従来のstandard-versionから変更された点
 
@@ -94,9 +97,21 @@ git merge feature/batch-processing
 git push origin main
 ```
 
-### 2. 手動リリース実行
+mainへのpush後、release-pleaseが自動的に既存のRelease PRを更新します。
 
-GitHub Actionsで「Release Please」ワークフローを手動実行します：
+### 2. Release PRの確認
+
+mainブランチへのpush後、またはワークフローの手動実行後：
+
+1. **Pull Requestsページを確認**: 「chore(main): release X.X.X」というタイトルのPRを探す
+2. **内容を確認**:
+   - CHANGELOGの変更内容
+   - package.jsonのバージョン
+   - 含まれるコミット一覧
+
+### 3. 手動でのリリースバージョン指定（オプション）
+
+特定のバージョンでリリースしたい場合：
 
 1. **GitHub Actionsページに移動**: リポジトリの「Actions」タブ
 2. **「Release Please」ワークフローを選択**
@@ -108,26 +123,19 @@ GitHub Actionsで「Release Please」ワークフローを手動実行します�
    - `major`: メジャーリリース (0.4.0 → 1.0.0)
 5. **「Run workflow」で実行**
 
-ワークフローが実行されると、release-pleaseが自動的に：
+### 4. リリース実行
 
-- コミット履歴を分析
-- セマンティックバージョニングに基づいてバージョン決定（またはマニュアル指定）
-- CHANGELOGを自動生成
-- package.jsonのバージョンを更新
-- **Release PR**を作成
+**Release PR**をマージすると自動的に：
 
-### 3. リリース実行
-
-**Release PR**をマージすると：
-
-1. **タグ作成**: `v0.4.1`のようなタグが自動作成
-2. **ビルド開始**: GitHub Actionsがビルドを開始
-3. **成果物生成**: 
+1. **品質チェック**: ESLint、TypeScript、テスト、ビルドチェックを実行
+2. **タグ作成**: `v0.4.1`のようなタグが自動作成
+3. **GitHub Release作成**: リリースノートとともに公開
+4. **ビルド実行**: 各プラットフォーム向けにビルド
    - macOS: `EPUB-Image-Extractor-{version}-arm64.dmg`
    - macOS: `EPUB-Image-Extractor-{version}-x64.dmg`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Setup.exe`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Portable.exe`
-4. **リリース作成**: GitHub Releaseが作成され、成果物がアップロード
+5. **成果物アップロード**: ビルド成果物をGitHub Releaseに自動追加
 
 ## 🛠 メンテナンス作業
 


### PR DESCRIPTION
## Summary
- PRの品質チェックとリリースワークフローを分離
- Release PRマージ時に自動的にリリースが作成されるように修正

## Problem
1. release-pleaseのRelease PRをマージしてもリリースが作成されない
2. 品質チェックがリリース時に実行されていた（本来はPR時に実行すべき）

## Changes
### 新しいワークフローファイル: pr-checks.yml
- すべてのPRに対して自動的に品質チェックを実行
- ESLint、TypeScript、テスト、ビルドチェック
- 結果をPRにコメントで通知

### release-please.yml の修正
- `push`トリガーを追加（mainブランチ）
- `pre-release-checks`ジョブを削除
- リリース作成とビルドのみに専念

### ドキュメントの更新
- PR時の自動品質チェックについて明記
- リリースフローの説明を更新

## New Workflow
1. **開発**: conventional commitsで開発
2. **PR作成/更新**: 
   - mainへのpush → release-pleaseが自動でRelease PR作成/更新
   - 手動実行 → 指定バージョンでRelease PR作成
3. **品質チェック**: PRが作成/更新されると自動的に実行
4. **リリース**: Release PRマージ → 自動的にリリース作成 → ビルド → 配布

## Benefits
- PRマージ前に問題を発見できる
- リリース時は確実に品質が保証されている
- リリースプロセスがより高速に

## Test plan
- [ ] PRが作成された時に品質チェックが実行される
- [ ] 品質チェックの結果がPRにコメントされる
- [ ] Release PRマージ時に自動的にリリースが作成される
- [ ] リリース時に余計なチェックが実行されない

🤖 Generated with [Claude Code](https://claude.ai/code)