### PR TITLE
docs: Add instructions for enabling PR Checks on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,12 @@ permissions:
   pull-requests: write
   issues: write
 
+# Note: PRs created with GITHUB_TOKEN won't trigger PR Checks workflow.
+# To enable PR Checks on release PRs, you need to use a Personal Access Token (PAT).
+# 1. Create a PAT with 'repo' scope
+# 2. Add it as a repository secret named 'RELEASE_TOKEN'
+# 3. Replace ${{ secrets.GITHUB_TOKEN }} with ${{ secrets.RELEASE_TOKEN }} below
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -31,6 +37,7 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Create Release PR (Explicit)
         uses: googleapis/release-please-action@v4
@@ -41,3 +48,4 @@ jobs:
           manifest-file: .release-please-manifest.json
           release-as: ${{ github.event.inputs.release_type }}
           skip-github-release: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -280,6 +280,26 @@ git push origin main
 - [ ] 重要な変更が含まれている場合、追加のテストを実行
 - [ ] 破壊的変更がある場合、マイグレーションガイドを作成
 
+## ⚙️ 初期設定
+
+### Release PRでPR Checksを有効にする
+
+デフォルトでは、GitHub Actionsの`GITHUB_TOKEN`で作成されたPRは他のワークフローをトリガーしません。Release PRでもPR Checksを実行するには、Personal Access Token (PAT)の設定が必要です：
+
+1. **Personal Access Tokenの作成**
+   - GitHubの Settings > Developer settings > Personal access tokens
+   - `repo`スコープを持つトークンを作成
+
+2. **リポジトリシークレットの追加**
+   - リポジトリの Settings > Secrets and variables > Actions
+   - `RELEASE_TOKEN`という名前でトークンを追加
+
+3. **ワークフローの更新**
+   - `.github/workflows/release-please.yml`の`token: ${{ secrets.GITHUB_TOKEN }}`を
+   - `token: ${{ secrets.RELEASE_TOKEN }}`に変更
+
+これにより、Release PRが作成された際に自動的にPR Checksが実行されます。
+
 ## 🚨 トラブルシューティング
 
 ### Release PRが作成されない場合


### PR DESCRIPTION
## Summary
- Document the GitHub Actions limitation where PRs created with GITHUB_TOKEN don't trigger other workflows
- Add setup instructions for using Personal Access Token (PAT) to enable PR Checks on release PRs
- Include this information in both the workflow comments and release documentation

## Context
Investigation showed that PR Checks workflow hasn't been running on release PRs (e.g., PR #15 for v0.4.2). This is due to a GitHub security feature that prevents workflows triggered by GITHUB_TOKEN from triggering other workflows.

## Solution
The recommended solution is to use a Personal Access Token (PAT) instead of GITHUB_TOKEN when creating release PRs. This documentation provides clear instructions for setting this up.

## Changes
1. Added comments to `release-please.yml` explaining the limitation
2. Added "Initial Setup" section to `RELEASE.md` with PAT configuration steps
3. Kept the token references as GITHUB_TOKEN (to be changed by the user when they add RELEASE_TOKEN)

Fixes the issue where release PRs don't have quality checks before merging.