### PR TITLE
docs: Update README files to reflect pino logging system

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -95,12 +95,13 @@ EPUB_Images/
 
 ### 技術スタック
 
-- **フレームワーク**: Electron 28
+- **フレームワーク**: Electron 37
 - **言語**: TypeScript 5
-- **UI**: React 18
-- **ビルドツール**: Vite 5
+- **UI**: React 19
+- **ビルドツール**: Vite 7
 - **EPUBパーサー**: xml2jsを使用したカスタム実装
 - **国際化**: i18next（日本語UI）
+- **ログシステム**: pino（高性能JSONロガー）
 
 ### アーキテクチャ
 
@@ -176,22 +177,16 @@ npm run typecheck
 
 ## トラブルシューティング
 
-### デバッグログの確認
+### ログの確認
 
-アプリケーションはデバッグ情報をファイルに記録しています。問題が発生した場合は、以下の場所でログファイルを確認できます：
+アプリケーションはpinoを使用してログを記録しています。問題が発生した場合は、以下の場所でログファイルを確認できます：
 
-- **Windows**: `%APPDATA%\epub-image-extractor\logs\`
-- **macOS**: `~/Library/Application Support/epub-image-extractor/logs/`
+- **Windows**: `%APPDATA%\epub-image-extractor\app.log`
+- **macOS**: `~/Library/Application Support/epub-image-extractor/app.log`
 
-ログファイル：
-- `error.log` - エラー情報のみ
-- `combined.log` - すべてのログ（情報、警告、エラー）
-- `debug.log` - 詳細なデバッグ情報
-
-開発時にコンソールにデバッグログを表示するには：
+開発時にデバッグログを有効にするには：
 ```bash
-# 環境変数を設定して実行
-LOG_LEVEL=debug npm run dev
+LOG_LEVEL=debug npm run electron:dev
 ```
 
 ### よくある問題

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ EPUB_Images/
 - **Build Tool**: Vite 7
 - **EPUB Parser**: Custom implementation using xml2js
 - **Internationalization**: i18next (Japanese UI)
+- **Logging**: pino (high-performance JSON logger)
 
 ### Architecture
 
@@ -224,6 +225,17 @@ The application uses a custom icon featuring an open book with floating images. 
 2. **Build failures on macOS**: You may need to install Xcode Command Line Tools
 3. **Large EPUB files**: Files with many images may take longer to process. The app will warn if resource limits are reached
 4. **Missing navigation/TOC**: EPUBs without proper navigation will have all images extracted to "001_未分類" folder
+
+### Logging
+
+The application uses pino for logging. Log files are located at:
+- **macOS**: `~/Library/Application Support/epub-image-extractor/app.log`
+- **Windows**: `%APPDATA%\epub-image-extractor\app.log`
+
+To enable debug logging in development:
+```bash
+LOG_LEVEL=debug npm run electron:dev
+```
 
 ## License
 


### PR DESCRIPTION
## Summary
- READMEファイルをpino移行後の最新状態に更新
- 英語版・日本語版の両方を更新

## Changes
### 技術スタックの更新
- pino（高性能JSONロガー）を技術スタックに追加
- バージョン番号を最新に修正（Electron 37、React 19、Vite 7）

### ログ関連ドキュメントの更新
- 正しいログファイルの場所を記載
  - macOS: `~/Library/Application Support/epub-image-extractor/app.log`
  - Windows: `%APPDATA%\epub-image-extractor\app.log`
- デバッグログの有効化方法を更新（`LOG_LEVEL=debug`）

### 古い情報の削除
- winston時代の3ファイル構成（error.log、combined.log、debug.log）の記述を削除
- 日本語版READMEの古いバージョン番号を修正

## Test Plan
- [x] 英語版READMEの内容確認
- [x] 日本語版READMEの内容確認
- [x] ログファイルパスの正確性確認

🤖 Generated with [Claude Code](https://claude.ai/code)