### PR TITLE
fix: Fix issue where '0' is displayed when files are dropped

### DIFF
--- a/src/renderer/__tests__/setup.tsx
+++ b/src/renderer/__tests__/setup.tsx
@@ -45,6 +45,7 @@ testI18n.use(initReactI18next).init({
           openFolder: 'フォルダを開く',
           clear: 'クリア',
           alreadyProcessing: '現在処理中です。完了までお待ちください。',
+          no_images: '画像なし',
         },
         settings: {
           title: '設定',
@@ -131,6 +132,7 @@ testI18n.use(initReactI18next).init({
           openFolder: 'Open Folder',
           clear: 'Clear',
           alreadyProcessing: 'Currently processing. Please wait until completion.',
+          no_images: 'No images',
         },
         settings: {
           title: 'Settings',

--- a/src/renderer/components/FileProcessingList.tsx
+++ b/src/renderer/components/FileProcessingList.tsx
@@ -138,25 +138,31 @@ export const FileProcessingList: React.FC<FileProcessingListProps> = ({
               <span className="file-name">{item.fileName}</span>
             </div>
 
-            {item.status === 'processing' && item.totalImages && item.totalImages > 0 && (
+            {item.status === 'processing' && (
               <>
-                <div className="progress-bar">
-                  <div
-                    className="progress-fill"
-                    style={{
-                      width: `${
-                        item.phase === 'organizing'
-                          ? '95%'
-                          : `${Math.min(95, ((item.processedImages || 0) / item.totalImages) * 100)}%`
-                      }`,
-                    }}
-                  />
-                </div>
-                <div className="progress-text">
-                  {item.phase === 'organizing'
-                    ? `${t('processing.organizing')} (${item.totalImages}${t('units.images')})`
-                    : `${t('processing.extracting')}: ${item.processedImages || 0} / ${item.totalImages}`}
-                </div>
+                {item.totalImages && item.totalImages > 0 ? (
+                  <>
+                    <div className="progress-bar">
+                      <div
+                        className="progress-fill"
+                        style={{
+                          width: `${
+                            item.phase === 'organizing'
+                              ? '95%'
+                              : `${Math.min(95, ((item.processedImages || 0) / item.totalImages) * 100)}%`
+                          }`,
+                        }}
+                      />
+                    </div>
+                    <div className="progress-text">
+                      {item.phase === 'organizing'
+                        ? `${t('processing.organizing')} (${item.totalImages}${t('units.images')})`
+                        : `${t('processing.extracting')}: ${item.processedImages || 0} / ${item.totalImages}`}
+                    </div>
+                  </>
+                ) : (
+                  <div className="progress-text">{t('processing.extracting')}</div>
+                )}
               </>
             )}
 

--- a/src/renderer/components/FileProcessingList.tsx
+++ b/src/renderer/components/FileProcessingList.tsx
@@ -167,9 +167,15 @@ export const FileProcessingList: React.FC<FileProcessingListProps> = ({
             {item.status === 'completed' && (
               <div className="completion-info">
                 <div className="result-text">
-                  {item.totalImages}
-                  {t('units.images')}
-                  {item.chapters ? `, ${item.chapters}${t('units.chapters')}` : ''}
+                  {item.totalImages && item.totalImages > 0 ? (
+                    <>
+                      {item.totalImages}
+                      {t('units.images')}
+                      {item.chapters ? `, ${item.chapters}${t('units.chapters')}` : ''}
+                    </>
+                  ) : (
+                    t('processing.no_images')
+                  )}
                 </div>
                 {item.outputPath && (
                   <button

--- a/src/renderer/components/__tests__/FileProcessingList.zero-display.test.tsx
+++ b/src/renderer/components/__tests__/FileProcessingList.zero-display.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen } from '../../__tests__/setup';
+import { FileProcessingList } from '../FileProcessingList';
+import { ProcessingProgress } from '@shared/types';
+
+describe('FileProcessingList - 「0」の表示問題', () => {
+  const mockOnClearAll = jest.fn();
+  const mockOnOpenFolder = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pending状態では「待機中」と表示され、「0」は表示されない', () => {
+    const progress: Record<string, ProcessingProgress> = {
+      'file-1': {
+        fileId: 'file-1',
+        fileName: 'test.epub',
+        totalImages: 0,
+        processedImages: 0,
+        status: 'pending',
+      },
+    };
+
+    render(
+      <FileProcessingList
+        progress={progress}
+        results={[]}
+        onClearAll={mockOnClearAll}
+        onOpenFolder={mockOnOpenFolder}
+      />,
+    );
+
+    // ファイル名が表示される
+    expect(screen.getByText('test.epub')).toBeInTheDocument();
+    
+    // 「待機中」と表示される
+    expect(screen.getByText('待機中')).toBeInTheDocument();
+    
+    // デバッグ情報を出力
+    const container = screen.getByText('test.epub').closest('.processing-item');
+    console.log('=== pending状態のレンダリング内容 ===');
+    console.log(container?.innerHTML);
+    
+    // 「0」という文字が表示されないことを確認
+    const zeroElements = screen.queryAllByText('0');
+    expect(zeroElements.length).toBe(0);
+    
+    // 「0画像」や「0 / 0」といった表示もないことを確認
+    expect(screen.queryByText(/0.*画像/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/0.*\/.*0/)).not.toBeInTheDocument();
+  });
+
+  it('processing状態でtotalImages=0の場合は「画像を抽出中...」と表示', () => {
+    const progress: Record<string, ProcessingProgress> = {
+      'file-1': {
+        fileId: 'file-1',
+        fileName: 'test.epub',
+        totalImages: 0,
+        processedImages: 0,
+        status: 'processing',
+        phase: 'extracting',
+      },
+    };
+
+    render(
+      <FileProcessingList
+        progress={progress}
+        results={[]}
+        onClearAll={mockOnClearAll}
+        onOpenFolder={mockOnOpenFolder}
+      />,
+    );
+
+    // 「画像を抽出中...」と表示される
+    expect(screen.getByText('画像を抽出中...')).toBeInTheDocument();
+    
+    // 「0」や「0 / 0」といった表示はない
+    expect(screen.queryByText(/0.*\/.*0/)).not.toBeInTheDocument();
+  });
+
+  it('completed状態でtotalImages=0の場合は「画像なし」と表示', () => {
+    const progress: Record<string, ProcessingProgress> = {
+      'file-1': {
+        fileId: 'file-1',
+        fileName: 'test.epub',
+        totalImages: 0,
+        processedImages: 0,
+        status: 'completed',
+      },
+    };
+
+    render(
+      <FileProcessingList
+        progress={progress}
+        results={[]}
+        onClearAll={mockOnClearAll}
+        onOpenFolder={mockOnOpenFolder}
+      />,
+    );
+
+    // 「画像なし」と表示される
+    expect(screen.getByText('画像なし')).toBeInTheDocument();
+    
+    // 「0」という単独の文字は表示されない
+    const zeroElements = screen.queryAllByText('0');
+    expect(zeroElements.length).toBe(0);
+  });
+});

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -27,7 +27,8 @@
     "pending_text": "Pending",
     "openFolder": "Open Folder",
     "clear": "Clear",
-    "alreadyProcessing": "Currently processing. Please wait until completion."
+    "alreadyProcessing": "Currently processing. Please wait until completion.",
+    "no_images": "No images"
   },
   "settings": {
     "title": "Settings",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -27,7 +27,8 @@
     "pending_text": "待機中",
     "openFolder": "フォルダを開く",
     "clear": "クリア",
-    "alreadyProcessing": "現在処理中です。完了までお待ちください。"
+    "alreadyProcessing": "現在処理中です。完了までお待ちください。",
+    "no_images": "画像なし"
   },
   "settings": {
     "title": "設定",


### PR DESCRIPTION
## Summary
Fixed the issue where "0" was displayed under the filename when EPUB files were dropped onto the application.

## Problem Details
### Symptoms
- When dropping EPUB files, a "0" appears under the filename before processing starts
- The expected behavior is to show "Extracting images..." message instead

### Root Cause
In `FileProcessingList.tsx`, the display logic for `processing` state with `totalImages=0` was incorrect:
```tsx
// Before: Nothing is displayed when totalImages is 0
{item.status === 'processing' && item.totalImages && item.totalImages > 0 && (
  // Progress display
)}
```

### When the Problem Started
- The issue existed since the initial implementation (early July 2025)
- `totalImages` remains 0 until EPUB parsing completes, causing nothing to be displayed during this period

## Changes
1. **Improved display logic for processing state**
   ```tsx
   // After: Shows appropriate message even when totalImages is 0
   {item.status === 'processing' && (
     <>
       {item.totalImages && item.totalImages > 0 ? (
         // Progress bar and status display
       ) : (
         <div className="progress-text">{t('processing.extracting')}</div>
       )}
     </>
   )}
   ```

2. **Improved completed state display** (previous commit)
   - Shows "No images" when `totalImages` is 0

3. **Added tests**
   - Added test cases to verify correct display for each state
   - Added missing translation keys to test setup

## Test Plan
- [x] Added and passed unit tests
- [x] All lint/typecheck/test checks pass
- [ ] Manual testing with actual EPUB files
  - [ ] Verify "0" is not displayed when files are dropped
  - [ ] Verify "Extracting images..." is properly displayed
  - [ ] Verify "No images" is displayed for EPUBs without images

🤖 Generated with [Claude Code](https://claude.ai/code)