### PR TITLE
refactor: replace async-mutex with custom SimpleMutex implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "async-mutex": "^0.5.0",
         "electron-store": "^8.2.0",
         "fast-xml-parser": "^5.2.5",
         "fflate": "^0.8.2",
@@ -5340,15 +5339,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/async-mutex": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
-      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -14894,6 +14884,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "dist:mac-arm64": "npm run build && electron-builder --mac --arm64"
   },
   "dependencies": {
-    "async-mutex": "^0.5.0",
     "electron-store": "^8.2.0",
     "fast-xml-parser": "^5.2.5",
     "fflate": "^0.8.2",

--- a/src/main/utils/mutex.test.ts
+++ b/src/main/utils/mutex.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from '@jest/globals';
+import { SimpleMutex } from './mutex';
+
+describe('SimpleMutex', () => {
+  test('should allow sequential access', async () => {
+    const mutex = new SimpleMutex();
+    const results: number[] = [];
+
+    const task = async (id: number) => {
+      const release = await mutex.acquire();
+      try {
+        results.push(id);
+        // Simulate async work
+        await new Promise(resolve => setTimeout(resolve, 10));
+        results.push(id * 10);
+      } finally {
+        release();
+      }
+    };
+
+    // Start multiple tasks concurrently
+    await Promise.all([task(1), task(2), task(3)]);
+
+    // Results should show sequential execution
+    expect(results).toEqual([1, 10, 2, 20, 3, 30]);
+  });
+
+  test('should handle multiple releases safely', async () => {
+    const mutex = new SimpleMutex();
+    const release = await mutex.acquire();
+
+    // Multiple releases should not throw
+    expect(() => {
+      release();
+      release();
+      release();
+    }).not.toThrow();
+  });
+
+  test('should maintain order of acquisition', async () => {
+    const mutex = new SimpleMutex();
+    const order: string[] = [];
+
+    // First lock
+    const release1 = await mutex.acquire();
+    order.push('acquired-1');
+
+    // Start second acquisition (will wait)
+    const acquire2Promise = mutex.acquire().then(release => {
+      order.push('acquired-2');
+      return release;
+    });
+
+    // Start third acquisition (will wait)
+    const acquire3Promise = mutex.acquire().then(release => {
+      order.push('acquired-3');
+      return release;
+    });
+
+    // Release first lock
+    order.push('releasing-1');
+    release1();
+
+    // Wait for second acquisition
+    const release2 = await acquire2Promise;
+    order.push('releasing-2');
+    release2();
+
+    // Wait for third acquisition
+    const release3 = await acquire3Promise;
+    order.push('releasing-3');
+    release3();
+
+    expect(order).toEqual([
+      'acquired-1',
+      'releasing-1',
+      'acquired-2',
+      'releasing-2',
+      'acquired-3',
+      'releasing-3',
+    ]);
+  });
+
+  test('should work correctly with try-finally pattern', async () => {
+    const mutex = new SimpleMutex();
+    let counter = 0;
+
+    const incrementWithMutex = async () => {
+      const release = await mutex.acquire();
+      try {
+        const current = counter;
+        await new Promise(resolve => setTimeout(resolve, 5));
+        counter = current + 1;
+      } finally {
+        release();
+      }
+    };
+
+    // Run 10 increments concurrently
+    await Promise.all(Array(10).fill(0).map(() => incrementWithMutex()));
+
+    // Counter should be exactly 10 (no race conditions)
+    expect(counter).toBe(10);
+  });
+
+  test('should handle errors in critical section', async () => {
+    const mutex = new SimpleMutex();
+    const results: string[] = [];
+
+    const taskWithError = async () => {
+      const release = await mutex.acquire();
+      try {
+        results.push('error-task-start');
+        throw new Error('Test error');
+      } finally {
+        results.push('error-task-released');
+        release();
+      }
+    };
+
+    const normalTask = async () => {
+      const release = await mutex.acquire();
+      try {
+        results.push('normal-task');
+      } finally {
+        release();
+      }
+    };
+
+    // Start both tasks
+    const errorPromise = taskWithError().catch(() => {});
+    const normalPromise = normalTask();
+
+    await Promise.all([errorPromise, normalPromise]);
+
+    // Normal task should still execute after error task
+    expect(results).toEqual([
+      'error-task-start',
+      'error-task-released',
+      'normal-task',
+    ]);
+  });
+});

--- a/src/main/utils/mutex.ts
+++ b/src/main/utils/mutex.ts
@@ -1,0 +1,39 @@
+/**
+ * Simple mutex implementation for synchronizing async operations
+ * 
+ * This is a lightweight alternative to async-mutex library,
+ * designed specifically for our use case of preventing race conditions
+ * in directory creation during parallel EPUB processing.
+ */
+export class SimpleMutex {
+  private promise: Promise<void> = Promise.resolve();
+
+  /**
+   * Acquire the mutex lock
+   * @returns A release function that must be called to release the lock
+   */
+  async acquire(): Promise<() => void> {
+    let release: () => void;
+    let released = false;
+    
+    // Store the current promise
+    const oldPromise = this.promise;
+    
+    // Create a new promise for the next waiter
+    this.promise = new Promise((resolve) => {
+      release = () => {
+        // Prevent multiple releases
+        if (!released) {
+          released = true;
+          resolve();
+        }
+      };
+    });
+
+    // Wait for the previous lock to be released
+    await oldPromise;
+    
+    // Return the release function
+    return release!;
+  }
+}

--- a/src/main/utils/outputPath.ts
+++ b/src/main/utils/outputPath.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 import fs from 'fs/promises';
-import { Mutex } from 'async-mutex';
+import { SimpleMutex } from './mutex';
 
 // 並列処理での競合を防ぐためのミューテックス
-const outputPathMutex = new Mutex();
+const outputPathMutex = new SimpleMutex();
 
 /**
  * 出力ディレクトリのパスを生成し、重複を避ける


### PR DESCRIPTION
## Summary
Removed async-mutex library and replaced it with a lightweight custom SimpleMutex implementation.

## Changes
- Remove async-mutex dependency
- Implement SimpleMutex class (src/main/utils/mutex.ts)
- Add comprehensive tests for SimpleMutex
- Update outputPath.ts to use SimpleMutex

## Motivation
- async-mutex was used in only one place (preventing race conditions in directory creation during parallel EPUB processing)
- Only simple mutex functionality was needed, library's additional features were unnecessary
- Reduce external dependencies and improve maintainability

## Testing
- ✅ SimpleMutex unit tests (5 test cases) all pass
- ✅ Existing outputPath.ts tests all pass
- ✅ Full test suite passes
- ✅ Build successful
- ✅ Lint/type check successful

## Implementation Details
The custom implementation is ~20 lines of simple code that:
- Fully covers the current use case
- Includes double-release prevention
- Uses the same API as async-mutex (only import change required)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>