### PR TITLE
feat(settings): update opacity settings to 5% increments with 85% default

### DIFF
--- a/src/main/constants/window.ts
+++ b/src/main/constants/window.ts
@@ -14,9 +14,9 @@ export const WINDOW_SIZES = {
 export const WINDOW_OPACITY = {
   active: 1.0,
   inactive: {
-    default: 0.8,
+    default: 0.85,
     min: 0.1,
     max: 1.0,
-    step: 0.1,
+    step: 0.05,
   },
 } as const;

--- a/src/renderer/components/__tests__/SettingsWindow.opacity.test.tsx
+++ b/src/renderer/components/__tests__/SettingsWindow.opacity.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '../../__tests__/setup';
+import { SettingsWindow } from '../SettingsWindow';
+
+// Electronのモック
+const mockElectronAPI = {
+  getVersion: jest.fn().mockResolvedValue({
+    version: '1.0.0',
+    name: 'EPUB Image Extractor',
+    electronVersion: '37.2.1',
+    nodeVersion: '24.1.0',
+    chromiumVersion: '132.0.6834.110',
+    platform: 'darwin',
+    arch: 'x64',
+  }),
+  getSettings: jest.fn().mockResolvedValue({
+    outputDirectory: '/test/path',
+    language: 'ja',
+    alwaysOnTop: true,
+    includeOriginalFilename: true,
+    includePageSpread: true,
+    inactiveOpacity: 0.85,
+    enableMouseHoverOpacity: true,
+  }),
+  saveSettings: jest.fn().mockResolvedValue({ success: true }),
+  selectOutputDirectory: jest.fn(),
+  resetSettings: jest.fn().mockResolvedValue({
+    outputDirectory: '/default/path',
+    language: 'ja',
+    alwaysOnTop: true,
+    includeOriginalFilename: true,
+    includePageSpread: true,
+    inactiveOpacity: 0.85,
+    enableMouseHoverOpacity: true,
+  }),
+};
+
+// window.electronAPIをモック
+Object.defineProperty(window, 'electronAPI', {
+  value: mockElectronAPI,
+  writable: true,
+});
+
+describe('SettingsWindow - 透明度設定', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('透明度スライダーが5%刻みで設定できる', async () => {
+    const { container } = render(<SettingsWindow isOpen={true} onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    const slider = container.querySelector('#inactive-opacity') as HTMLInputElement;
+    
+    // スライダーの属性を確認
+    expect(slider.min).toBe('0.1');
+    expect(slider.max).toBe('1');
+    expect(slider.step).toBe('0.05'); // 5%刻み
+    expect(slider.value).toBe('0.85'); // 初期値85%
+  });
+
+  test('透明度の値が正しくパーセント表示される', async () => {
+    render(<SettingsWindow isOpen={true} onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+  });
+
+  test('透明度を変更すると値が更新される', async () => {
+    const { container } = render(<SettingsWindow isOpen={true} onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    const slider = container.querySelector('#inactive-opacity') as HTMLInputElement;
+    
+    // 50%に変更
+    fireEvent.change(slider, { target: { value: '0.5' } });
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    
+    // 100%に変更
+    fireEvent.change(slider, { target: { value: '1' } });
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    
+    // 10%に変更
+    fireEvent.change(slider, { target: { value: '0.1' } });
+    expect(screen.getByText('10%')).toBeInTheDocument();
+  });
+
+  test('5%刻みの値のみ設定可能', async () => {
+    const { container } = render(<SettingsWindow isOpen={true} onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    const slider = container.querySelector('#inactive-opacity') as HTMLInputElement;
+    
+    // 有効な値のテスト (5%刻み)
+    const validValues = [0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 1.0];
+    
+    validValues.forEach(value => {
+      fireEvent.change(slider, { target: { value: String(value) } });
+      expect(slider.value).toBe(String(value));
+    });
+  });
+
+  test('リセット時に透明度が85%に戻る', async () => {
+    const { container } = render(<SettingsWindow isOpen={true} onClose={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+
+    const slider = container.querySelector('#inactive-opacity') as HTMLInputElement;
+    
+    // 値を変更
+    fireEvent.change(slider, { target: { value: '0.5' } });
+    expect(screen.getByText('50%')).toBeInTheDocument();
+    
+    // リセットボタンをクリック
+    const resetButton = screen.getByText('デフォルトに戻す');
+    fireEvent.click(resetButton);
+    
+    await waitFor(() => {
+      expect(slider.value).toBe('0.85');
+      expect(screen.getByText('85%')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Change opacity step from 10% to 5% increments for finer control
- Update default inactive opacity from 80% to 85% for better visibility
- Add comprehensive tests for opacity settings

## Changes
- Updated `WINDOW_OPACITY` constants in `src/main/constants/window.ts`
  - Changed `step` from 0.1 to 0.05 (5% increments)
  - Changed `default` from 0.8 to 0.85 (85% default)
- Added new test file `SettingsWindow.opacity.test.tsx` with comprehensive test coverage

## Test Plan
- [x] Added unit tests for opacity slider functionality
- [x] Verified 5% increment steps work correctly
- [x] Confirmed default value is 85%
- [x] Tested reset functionality returns to 85%
- [x] All tests pass (`npm test`)
- [x] No lint errors (`npm run lint`)
- [x] No type errors (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.ai/code)