### PR TITLE
fix: handle clearWindowBounds errors gracefully in settings save

### DIFF
--- a/src/renderer/__tests__/SettingsWindow.reset.test.tsx
+++ b/src/renderer/__tests__/SettingsWindow.reset.test.tsx
@@ -62,36 +62,29 @@ describe('SettingsWindow - Reset and Save behavior', () => {
   test('通常の保存ではウィンドウが閉じる', async () => {
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // Wait for save to complete
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
 
-    // clearWindowBounds should not be called
     expect(mockClearWindowBounds).not.toHaveBeenCalled();
 
-    // Window should close
     expect(mockOnClose).toHaveBeenCalled();
   });
 
   test('リセット後の保存でもウィンドウが閉じる', async () => {
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // Click reset button
     const resetButton = screen.getByText('settings.actions.reset');
     fireEvent.click(resetButton);
 
@@ -99,19 +92,15 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect(mockResetSettings).toHaveBeenCalled();
     });
 
-    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // Wait for save to complete
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
 
-    // clearWindowBounds should be called
     expect(mockClearWindowBounds).toHaveBeenCalled();
 
-    // Window should close
     expect(mockOnClose).toHaveBeenCalled();
   });
 
@@ -119,17 +108,14 @@ describe('SettingsWindow - Reset and Save behavior', () => {
     // Make clearWindowBounds throw an error
     mockClearWindowBounds.mockRejectedValue(new Error('Failed to clear window bounds'));
 
-    // Mock console.warn
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // Click reset button
     const resetButton = screen.getByText('settings.actions.reset');
     fireEvent.click(resetButton);
 
@@ -137,11 +123,9 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect(mockResetSettings).toHaveBeenCalled();
     });
 
-    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // Wait for save attempt
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
@@ -157,7 +141,6 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect.any(Error),
     );
 
-    // Window should close (even with error)
     expect(mockOnClose).toHaveBeenCalled();
 
     consoleWarnSpy.mockRestore();

--- a/src/renderer/__tests__/SettingsWindow.reset.test.tsx
+++ b/src/renderer/__tests__/SettingsWindow.reset.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SettingsWindow } from '../components/SettingsWindow';
 
-// i18nextのモック
+// Mock i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -27,7 +27,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // window.electronAPIのモック
+    // Mock window.electronAPI
     (global as any).window.electronAPI = {
       getSettings: mockGetSettings,
       saveSettings: mockSaveSettings,
@@ -62,36 +62,36 @@ describe('SettingsWindow - Reset and Save behavior', () => {
   test('通常の保存ではウィンドウが閉じる', async () => {
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // 設定が読み込まれるのを待つ
+    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // 保存ボタンをクリック
+    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // 保存処理が完了するのを待つ
+    // Wait for save to complete
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
 
-    // clearWindowBoundsは呼ばれない
+    // clearWindowBounds should not be called
     expect(mockClearWindowBounds).not.toHaveBeenCalled();
 
-    // ウィンドウが閉じられる
+    // Window should close
     expect(mockOnClose).toHaveBeenCalled();
   });
 
   test('リセット後の保存でもウィンドウが閉じる', async () => {
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // 設定が読み込まれるのを待つ
+    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // リセットボタンをクリック
+    // Click reset button
     const resetButton = screen.getByText('settings.actions.reset');
     fireEvent.click(resetButton);
 
@@ -99,37 +99,37 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect(mockResetSettings).toHaveBeenCalled();
     });
 
-    // 保存ボタンをクリック
+    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // 保存処理が完了するのを待つ
+    // Wait for save to complete
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
 
-    // clearWindowBoundsが呼ばれる
+    // clearWindowBounds should be called
     expect(mockClearWindowBounds).toHaveBeenCalled();
 
-    // ウィンドウが閉じられる
+    // Window should close
     expect(mockOnClose).toHaveBeenCalled();
   });
 
   test('clearWindowBoundsでエラーが発生しても、設定は保存されウィンドウは閉じる', async () => {
-    // clearWindowBoundsがエラーを投げるように設定
+    // Make clearWindowBounds throw an error
     mockClearWindowBounds.mockRejectedValue(new Error('Failed to clear window bounds'));
 
-    // console.warnをモック
+    // Mock console.warn
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
-    // 設定が読み込まれるのを待つ
+    // Wait for settings to load
     await waitFor(() => {
       expect(mockGetSettings).toHaveBeenCalled();
     });
 
-    // リセットボタンをクリック
+    // Click reset button
     const resetButton = screen.getByText('settings.actions.reset');
     fireEvent.click(resetButton);
 
@@ -137,16 +137,16 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect(mockResetSettings).toHaveBeenCalled();
     });
 
-    // 保存ボタンをクリック
+    // Click save button
     const saveButton = screen.getByText('settings.actions.save');
     fireEvent.click(saveButton);
 
-    // 保存処理が試行されるのを待つ
+    // Wait for save attempt
     await waitFor(() => {
       expect(mockSaveSettings).toHaveBeenCalled();
     });
 
-    // clearWindowBoundsが呼ばれる
+    // clearWindowBounds should be called
     await waitFor(() => {
       expect(mockClearWindowBounds).toHaveBeenCalled();
     });
@@ -157,7 +157,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect.any(Error),
     );
 
-    // ウィンドウは閉じられる（エラーがあっても）
+    // Window should close (even with error)
     expect(mockOnClose).toHaveBeenCalled();
 
     consoleWarnSpy.mockRestore();

--- a/src/renderer/__tests__/SettingsWindow.reset.test.tsx
+++ b/src/renderer/__tests__/SettingsWindow.reset.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SettingsWindow } from '../components/SettingsWindow';
+
+// i18nextのモック
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: 'ja',
+      changeLanguage: vi.fn(),
+    },
+  }),
+}));
+
+describe('SettingsWindow - Reset and Save behavior', () => {
+  const mockOnClose = vi.fn();
+  const mockOnShowAbout = vi.fn();
+  const mockGetSettings = vi.fn();
+  const mockSaveSettings = vi.fn();
+  const mockResetSettings = vi.fn();
+  const mockClearWindowBounds = vi.fn();
+  const mockSelectOutputDirectory = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // window.electronAPIのモック
+    (global as any).window.electronAPI = {
+      getSettings: mockGetSettings,
+      saveSettings: mockSaveSettings,
+      resetSettings: mockResetSettings,
+      clearWindowBounds: mockClearWindowBounds,
+      selectOutputDirectory: mockSelectOutputDirectory,
+    };
+
+    mockGetSettings.mockResolvedValue({
+      outputDirectory: '/test/output',
+      language: 'ja',
+      alwaysOnTop: true,
+      includeOriginalFilename: true,
+      includePageSpread: true,
+      inactiveOpacity: 0.8,
+      enableMouseHoverOpacity: true,
+    });
+
+    mockSaveSettings.mockResolvedValue({ success: true });
+    mockResetSettings.mockResolvedValue({
+      outputDirectory: '/default/output',
+      language: 'ja',
+      alwaysOnTop: true,
+      includeOriginalFilename: true,
+      includePageSpread: true,
+      inactiveOpacity: 0.8,
+      enableMouseHoverOpacity: true,
+    });
+    mockClearWindowBounds.mockResolvedValue({ success: true });
+  });
+
+  test('通常の保存ではウィンドウが閉じる', async () => {
+    render(
+      <SettingsWindow
+        isOpen={true}
+        onClose={mockOnClose}
+        onShowAbout={mockOnShowAbout}
+      />
+    );
+
+    // 設定が読み込まれるのを待つ
+    await waitFor(() => {
+      expect(mockGetSettings).toHaveBeenCalled();
+    });
+
+    // 保存ボタンをクリック
+    const saveButton = screen.getByText('settings.actions.save');
+    fireEvent.click(saveButton);
+
+    // 保存処理が完了するのを待つ
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalled();
+    });
+
+    // clearWindowBoundsは呼ばれない
+    expect(mockClearWindowBounds).not.toHaveBeenCalled();
+
+    // ウィンドウが閉じられる
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  test('リセット後の保存でもウィンドウが閉じる', async () => {
+    render(
+      <SettingsWindow
+        isOpen={true}
+        onClose={mockOnClose}
+        onShowAbout={mockOnShowAbout}
+      />
+    );
+
+    // 設定が読み込まれるのを待つ
+    await waitFor(() => {
+      expect(mockGetSettings).toHaveBeenCalled();
+    });
+
+    // リセットボタンをクリック
+    const resetButton = screen.getByText('settings.actions.reset');
+    fireEvent.click(resetButton);
+
+    await waitFor(() => {
+      expect(mockResetSettings).toHaveBeenCalled();
+    });
+
+    // 保存ボタンをクリック
+    const saveButton = screen.getByText('settings.actions.save');
+    fireEvent.click(saveButton);
+
+    // 保存処理が完了するのを待つ
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalled();
+    });
+
+    // clearWindowBoundsが呼ばれる
+    expect(mockClearWindowBounds).toHaveBeenCalled();
+
+    // ウィンドウが閉じられる
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  test('clearWindowBoundsでエラーが発生しても、設定は保存されウィンドウは閉じる', async () => {
+    // clearWindowBoundsがエラーを投げるように設定
+    mockClearWindowBounds.mockRejectedValue(new Error('Failed to clear window bounds'));
+
+    // console.warnをモック
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <SettingsWindow
+        isOpen={true}
+        onClose={mockOnClose}
+        onShowAbout={mockOnShowAbout}
+      />
+    );
+
+    // 設定が読み込まれるのを待つ
+    await waitFor(() => {
+      expect(mockGetSettings).toHaveBeenCalled();
+    });
+
+    // リセットボタンをクリック
+    const resetButton = screen.getByText('settings.actions.reset');
+    fireEvent.click(resetButton);
+
+    await waitFor(() => {
+      expect(mockResetSettings).toHaveBeenCalled();
+    });
+
+    // 保存ボタンをクリック
+    const saveButton = screen.getByText('settings.actions.save');
+    fireEvent.click(saveButton);
+
+    // 保存処理が試行されるのを待つ
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalled();
+    });
+
+    // clearWindowBoundsが呼ばれる
+    await waitFor(() => {
+      expect(mockClearWindowBounds).toHaveBeenCalled();
+    });
+
+    // 警告がログに出力される
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:',
+      expect.any(Error)
+    );
+
+    // ウィンドウは閉じられる（エラーがあっても）
+    expect(mockOnClose).toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/renderer/__tests__/SettingsWindow.reset.test.tsx
+++ b/src/renderer/__tests__/SettingsWindow.reset.test.tsx
@@ -60,13 +60,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
   });
 
   test('通常の保存ではウィンドウが閉じる', async () => {
-    render(
-      <SettingsWindow
-        isOpen={true}
-        onClose={mockOnClose}
-        onShowAbout={mockOnShowAbout}
-      />
-    );
+    render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
     // 設定が読み込まれるのを待つ
     await waitFor(() => {
@@ -90,13 +84,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
   });
 
   test('リセット後の保存でもウィンドウが閉じる', async () => {
-    render(
-      <SettingsWindow
-        isOpen={true}
-        onClose={mockOnClose}
-        onShowAbout={mockOnShowAbout}
-      />
-    );
+    render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
     // 設定が読み込まれるのを待つ
     await waitFor(() => {
@@ -134,13 +122,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
     // console.warnをモック
     const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    render(
-      <SettingsWindow
-        isOpen={true}
-        onClose={mockOnClose}
-        onShowAbout={mockOnShowAbout}
-      />
-    );
+    render(<SettingsWindow isOpen={true} onClose={mockOnClose} onShowAbout={mockOnShowAbout} />);
 
     // 設定が読み込まれるのを待つ
     await waitFor(() => {
@@ -172,7 +154,7 @@ describe('SettingsWindow - Reset and Save behavior', () => {
     // 警告がログに出力される
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       'ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:',
-      expect.any(Error)
+      expect.any(Error),
     );
 
     // ウィンドウは閉じられる（エラーがあっても）

--- a/src/renderer/__tests__/SettingsWindow.reset.test.tsx
+++ b/src/renderer/__tests__/SettingsWindow.reset.test.tsx
@@ -151,9 +151,9 @@ describe('SettingsWindow - Reset and Save behavior', () => {
       expect(mockClearWindowBounds).toHaveBeenCalled();
     });
 
-    // 警告がログに出力される
+    // Warning is logged
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:',
+      'Failed to reset window bounds, but settings were saved:',
       expect.any(Error),
     );
 

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -87,7 +87,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       onClose();
     } catch (error) {
       console.error('設定の保存に失敗しました:', error);
-      // ユーザーにエラーを通知（本来はUIで表示すべき）
+      // ユーザーにエラーを通知
       alert('設定の保存に失敗しました。詳細はコンソールをご確認ください。');
     } finally {
       setIsSaving(false);

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -73,12 +73,19 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
 
       // リセット後の保存の場合、ウィンドウサイズもデフォルトに戻す
       if (wasReset) {
-        await window.electronAPI.clearWindowBounds();
+        try {
+          await window.electronAPI.clearWindowBounds();
+        } catch (clearError) {
+          // clearWindowBoundsのエラーは警告として扱い、保存自体は成功とする
+          console.warn('ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:', clearError);
+        }
       }
 
       onClose();
     } catch (error) {
       console.error('設定の保存に失敗しました:', error);
+      // ユーザーにエラーを通知（本来はUIで表示すべき）
+      alert('設定の保存に失敗しました。詳細はコンソールをご確認ください。');
     } finally {
       setIsSaving(false);
     }

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -77,7 +77,10 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
           await window.electronAPI.clearWindowBounds();
         } catch (clearError) {
           // clearWindowBoundsのエラーは警告として扱い、保存自体は成功とする
-          console.warn('ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:', clearError);
+          console.warn(
+            'ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:',
+            clearError,
+          );
         }
       }
 

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -71,23 +71,20 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
 
       await window.electronAPI.saveSettings(settings);
 
-      // リセット後の保存の場合、ウィンドウサイズもデフォルトに戻す
+      // Reset window size to default after reset
       if (wasReset) {
         try {
           await window.electronAPI.clearWindowBounds();
         } catch (clearError) {
-          // clearWindowBoundsのエラーは警告として扱い、保存自体は成功とする
-          console.warn(
-            'ウィンドウサイズのリセットに失敗しましたが、設定は保存されました:',
-            clearError,
-          );
+          // Treat window bounds reset errors as warnings, not failures
+          console.warn('Failed to reset window bounds, but settings were saved:', clearError);
         }
       }
 
       onClose();
     } catch (error) {
-      console.error('設定の保存に失敗しました:', error);
-      // ユーザーにエラーを通知
+      console.error('Failed to save settings:', error);
+      // Notify user of error
       alert('設定の保存に失敗しました。詳細はコンソールをご確認ください。');
     } finally {
       setIsSaving(false);

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -84,7 +84,6 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       onClose();
     } catch (error) {
       console.error('Failed to save settings:', error);
-      // Notify user of error
       alert('設定の保存に失敗しました。詳細はコンソールをご確認ください。');
     } finally {
       setIsSaving(false);

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -37,7 +37,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
 
   useEffect(() => {
     if (isOpen) {
-      // 設定を読み込む
+      // Load settings
       window.electronAPI.getSettings().then((loadedSettings) => {
         setSettings({
           outputDirectory: loadedSettings.outputDirectory ?? '',
@@ -49,7 +49,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
           enableMouseHoverOpacity: loadedSettings.enableMouseHoverOpacity ?? true,
         });
       });
-      // ダイアログを開いたときにリセットフラグをクリア
+      // Clear reset flag when dialog opens
       setWasReset(false);
     }
   }, [isOpen]);
@@ -64,7 +64,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
   const handleSave = async () => {
     setIsSaving(true);
     try {
-      // 言語設定が変更された場合、i18nの言語を変更
+      // Change i18n language if language setting changed
       if (settings.language !== i18n.language) {
         i18n.changeLanguage(settings.language);
       }
@@ -102,7 +102,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       inactiveOpacity: defaultSettings.inactiveOpacity ?? WINDOW_OPACITY.inactive.default,
       enableMouseHoverOpacity: defaultSettings.enableMouseHoverOpacity ?? true,
     });
-    // リセットフラグを設定
+    // Set reset flag
     setWasReset(true);
   };
 

--- a/src/renderer/components/SettingsWindow.tsx
+++ b/src/renderer/components/SettingsWindow.tsx
@@ -84,7 +84,7 @@ export const SettingsWindow: React.FC<SettingsWindowProps> = ({ isOpen, onClose,
       onClose();
     } catch (error) {
       console.error('Failed to save settings:', error);
-      alert('設定の保存に失敗しました。詳細はコンソールをご確認ください。');
+      alert(t('errors.SETTINGS_SAVE_ERROR_DETAIL'));
     } finally {
       setIsSaving(false);
     }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -96,6 +96,7 @@
     "NAV_TOC_NOT_FOUND": "TOC not found in Navigation Document",
     "VERSION_INFO_ERROR": "Failed to get version information",
     "SETTINGS_SAVE_ERROR": "Failed to save settings",
+    "SETTINGS_SAVE_ERROR_DETAIL": "Failed to save settings. Please check the console for details.",
     "INVALID_EPUB_FORMAT": "Invalid EPUB format",
     "ZIP_EXTRACTION_ERROR": "Failed to extract ZIP file",
     "OUTPUT_DIR_ERROR": "Failed to create output directory",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -96,6 +96,7 @@
     "NAV_TOC_NOT_FOUND": "Navigation Documentにtocが見つかりません",
     "VERSION_INFO_ERROR": "バージョン情報の取得に失敗しました",
     "SETTINGS_SAVE_ERROR": "設定の保存に失敗しました",
+    "SETTINGS_SAVE_ERROR_DETAIL": "設定の保存に失敗しました。詳細はコンソールをご確認ください。",
     "INVALID_EPUB_FORMAT": "無効なEPUB形式です",
     "ZIP_EXTRACTION_ERROR": "ZIPファイルの展開に失敗しました",
     "OUTPUT_DIR_ERROR": "出力ディレクトリの作成に失敗しました",


### PR DESCRIPTION
## Summary
- Fix settings window not closing after 'Reset to defaults' → 'Save' sequence
- Add error handling for clearWindowBounds to prevent save failure
- Add comprehensive tests for reset → save behavior

## Problem
When clicking 'Reset to defaults' then 'Save', the settings window would not close if clearWindowBounds encountered an error.

## Solution
- Wrap clearWindowBounds in try-catch to handle errors gracefully
- Treat window bounds reset errors as warnings, not failures
- Ensure settings window closes even if bounds reset fails

## Test Coverage
- Normal save operation ✅
- Reset → Save operation ✅
- Error handling for clearWindowBounds ✅

🤖 Generated with [Claude Code](https://claude.ai/code)