### PR TITLE
chore: update merge rules to allow merging without requiring up-to-date branches

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -40,7 +40,7 @@
             "context": "quick-validation"
           }
         ],
-        "strict_required_status_checks_policy": true
+        "strict_required_status_checks_policy": false
       }
     }
   ],


### PR DESCRIPTION
## Summary
- Updated GitHub ruleset configuration to allow merging PRs without requiring them to be up-to-date with main
- Changed `strict_required_status_checks_policy` from `true` to `false`
- The ruleset has already been applied via GitHub API

## Changes
- Modified `.github/rulesets/main-branch-protection.json` to reflect the new setting
- PRs can now be merged if they pass required checks, even if not up-to-date with main
- Conflicts will still automatically block merging
- This improves development efficiency when using squash merge

## Benefits
- No need to constantly update branches when other PRs are merged
- Reduces unnecessary CI runs for updates that don't affect the code
- Particularly effective with squash merge strategy

## Safety
- GitHub still detects and blocks merging when conflicts exist
- Squash merge ensures final commit is applied to latest main
- All required checks (lint, typecheck, tests, build) must still pass
- Post-merge validation via main-validation.yml provides additional safety

🤖 Generated with [Claude Code](https://claude.ai/code)