### PR TITLE
fix: update TypeScript moduleResolution for @vitejs/plugin-react v5 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Updated TypeScript `moduleResolution` from `"node"` to `"bundler"` to fix compatibility with @vitejs/plugin-react v5.0.0
- This resolves the TypeScript errors in PR #66 that were blocking the dependency update

## Problem
PR #66 (Dependabot update for @vitejs/plugin-react v5.0.0) was failing with TypeScript errors:
```
error TS2307: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations.
```

## Solution
The @vitejs/plugin-react v5.0.0 requires a different module resolution strategy. The package now exports its types in a way that requires `moduleResolution: "bundler"` instead of the legacy `"node"` setting.

## Changes
- Updated `tsconfig.json`: Changed `moduleResolution` from `"node"` to `"bundler"`

## Testing
- ✅ TypeScript compilation: `npm run typecheck` - passes
- ✅ ESLint: `npm run lint` - passes  
- ✅ Build: `npm run build` - successful
- ✅ Tests: `npm test` - all tests pass

## Impact
- This change is fully backward compatible
- Enables us to proceed with the @vitejs/plugin-react v5.0.0 update
- Modernizes our TypeScript configuration

## Related
- Fixes CI failures in #66
- Required for @vitejs/plugin-react v5.0.0 compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)