### PR TITLE
chore(deps): update Electron to 37.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@vitest/ui": "^3.2.4",
         "concurrently": "^9.2.1",
         "conventional-commits-parser": "^6.2.0",
-        "electron": "^37.4.0",
+        "electron": "^37.5.0",
         "electron-builder": "^26.0.12",
         "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
@@ -5864,9 +5864,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "37.4.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-37.4.0.tgz",
-      "integrity": "sha512-HhsSdWowE5ODOeWNc/323Ug2C52mq/TqNBG+4uMeOA3G2dMXNc/nfyi0RYu1rJEgiaJLEjtHveeZZaYRYFsFCQ==",
+      "version": "37.5.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.5.0.tgz",
+      "integrity": "sha512-wOLJoa+XLS+KioTygttvadJ9252utQ3APJuVc72BK6QWH9dof8T/Y+On8cba7V/wtlPaPgyxmI8A0VhPngqqlw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@vitest/ui": "^3.2.4",
     "concurrently": "^9.2.1",
     "conventional-commits-parser": "^6.2.0",
-    "electron": "^37.4.0",
+    "electron": "^37.5.0",
     "electron-builder": "^26.0.12",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary
- Update Electron from 37.4.0 to 37.5.0
- Adopt the latest stable version of 37.x series for bug fixes and improvements

## Changes in Electron 37.5.0
- Updated Chromium to 138.0.7204.251
- Updated Node.js to v22.19.0
- Added macOS memory info fields (fileBacked, purgeable)
- Fixed dialog centering issues
- Fixed file picker directory selection problems
- Fixed dragging functionality after context menu events

## Electron 38 Migration Considerations

### Reasons to Postpone Migration

1. **macOS 11 (Big Sur) Support Dropped**
   - Electron 38 requires macOS 12 (Monterey) or later
   - Enterprise environments may still use older OS versions

2. **electron-builder Compatibility Uncertainty**
   - Current v26.0.12 compatibility with Electron 38 is unclear
   - Latest v26.0.20 has no explicit Electron 38 support mention

3. **Risk vs Benefit Imbalance**
   - Current Electron 37.4.0 is stable
   - Electron 38 new features are not required for this project
   - Breaking changes risk outweighs benefits

### Recommended Actions

1. Wait 3-6 months to confirm electron-builder support
2. Monitor macOS 11 EOL status (security support ended Sep 2024)
3. Consider phased migration:
   - Update to latest Electron 37 patch (this PR)
   - Update electron-builder and verify compatibility
   - Migrate to Electron 38 after thorough testing

## Test plan
- [x] `npm run build` - Build success confirmed
- [x] `npm run lint` - Lint checks passed
- [x] `npm test` - All 364 tests passed
- [ ] macOS functionality verification
- [ ] Windows functionality verification (CI)

🤖 Generated with [Claude Code](https://claude.ai/code)