### PR TITLE
fix(deps): configure Dependabot to use fix prefix for production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,7 +40,9 @@ updates:
     allow:
       - dependency-type: "all"
     # Commit message configuration
+    # Production deps use "fix" to trigger releases
+    # Development deps use "chore" as they don't affect users
     commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
+      prefix: "fix"              # Production dependencies
+      prefix-development: "chore" # Development dependencies
       include: "scope"


### PR DESCRIPTION
## Summary
- Configure Dependabot to use `fix(deps):` for production dependencies
- Keep `chore(deps-dev):` for development dependencies
- Enable proper release generation for dependency updates

## Problem
Currently, all dependency updates use `chore(deps):` which doesn't trigger releases in Release Please, even though production dependency updates affect users and should be included in changelogs.

## Solution
Update Dependabot configuration to use appropriate commit prefixes:
- **Production dependencies**: `fix(deps):` → Triggers patch releases
- **Development dependencies**: `chore(deps-dev):` → No release needed

## Impact
- Production dependency updates will now properly trigger releases
- Changelogs will include dependency updates in the "Bug Fixes" section
- Development dependency updates remain excluded from releases

## Configuration Change
```yaml
commit-message:
  prefix: "fix"              # Production dependencies
  prefix-development: "chore" # Development dependencies
  include: "scope"
```

## Examples of Future Commit Messages
- Production: `fix(deps): bump react from 19.0.0 to 19.1.0`
- Development: `chore(deps-dev): bump eslint from 8.0.0 to 9.0.0`

## Test Plan
- [x] Validate YAML syntax
- [x] Confirm configuration follows Dependabot documentation
- [ ] Monitor next Dependabot PR for correct prefix usage

🤖 Generated with [Claude Code](https://claude.ai/code)