### PR TITLE
fix: regenerate pnpm-lock.yaml to remove duplicated keys

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3219,10 +3219,6 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -7091,11 +7087,6 @@ snapshots:
   tinyexec@0.3.2: {}
 
   tinyexec@1.1.1: {}
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
## Summary
- `pnpm-lock.yaml` 内の `tinyglobby@0.2.16` 重複キーにより CI で `ERR_PNPM_BROKEN_LOCKFILE` が発生
- Dependabot PR #252 と #253 がリベースなしに相次いでマージされたことが原因
- バイト単位で同一の重複ブロック（2箇所・計9行）を手動で削除

## 影響範囲
main ブランチが壊れていたため、lockfile を変更するすべての open PR（#246, #254, #255, #256, #258 など）の `quick-validation` が失敗していました。本PRマージ後、各PRはリベースで復旧します。

## Test plan
- [x] `pnpm install --frozen-lockfile` 成功
- [x] `pnpm build` 成功
- [x] `pnpm lint` 成功
- [x] `pnpm test` 成功（410 tests pass）
- [ ] CI の `quick-validation` が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)