### PR TITLE
fix(ci): accept an exact version for the release_as input

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -3,16 +3,11 @@ name: Prepare Release PR
 on:
   workflow_dispatch:
     inputs:
-      release_type:
-        description: 'Type of release'
+      release_as:
+        description: 'Explicit version to release, e.g. 0.8.0. Leave empty to derive it from conventional commits.'
         required: false
-        default: 'auto'
-        type: choice
-        options:
-          - 'auto'
-          - 'patch'
-          - 'minor'
-          - 'major'
+        default: ''
+        type: string
 
 permissions:
   contents: write
@@ -23,21 +18,34 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # release-as accepts an exact version string only, never keywords like
+      # "patch"/"minor"/"major". Reject anything that is not semver so a typo
+      # fails loudly instead of producing a bogus release PR.
+      - name: Validate release_as
+        if: inputs.release_as != ''
+        env:
+          RELEASE_AS: ${{ inputs.release_as }}
+        run: |
+          if [[ ! "$RELEASE_AS" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$ ]]; then
+            echo "::error::release_as must be an exact version such as 0.8.0 (got: $RELEASE_AS)"
+            exit 1
+          fi
+
       - name: Create Release PR (Auto)
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
-        if: github.event.inputs.release_type == 'auto' || github.event.inputs.release_type == ''
+        if: inputs.release_as == ''
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-github-release: true
-      
+
       - name: Create Release PR (Explicit)
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release-explicit
-        if: github.event.inputs.release_type != 'auto' && github.event.inputs.release_type != ''
+        if: inputs.release_as != ''
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          release-as: ${{ github.event.inputs.release_type }}
+          release-as: ${{ inputs.release_as }}
           skip-github-release: true

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -136,12 +136,21 @@ Release PRは手動でワークフローを実行した時のみ作成・更新�
 1. **GitHub Actionsページに移動**: リポジトリの「Actions」タブ
 2. **「Prepare Release PR」ワークフローを選択**
 3. **「Run workflow」をクリック**
-4. **リリースタイプを選択**:
-   - `auto`: コミット履歴から自動決定（推奨）
-   - `patch`: パッチリリース (0.4.0 → 0.4.1)
-   - `minor`: マイナーリリース (0.4.0 → 0.5.0)
-   - `major`: メジャーリリース (0.4.0 → 1.0.0)
+4. **`release_as` にバージョンを入力**:
+   - 空欄: コミット履歴から自動決定（推奨）
+   - `0.8.0` のような**正確なバージョン文字列**: そのバージョンでRelease PRを作成
 5. **「Run workflow」で実行**
+
+> **注意**: `release_as` は release-please の `release-as` にそのまま渡されます。この設定は
+> 正確なバージョン文字列のみを受け付け、`patch` / `minor` / `major` のようなキーワードは
+> 使えません。誤入力はワークフロー冒頭の検証ステップで弾かれます。
+
+コミット経由で指定することもできます。`main` へのコミット本文に `Release-As: x.y.z` を
+含めると、release-please がそのバージョンでRelease PRを作成します。
+
+```bash
+git commit --allow-empty -m "chore: release 0.8.0" -m "Release-As: 0.8.0"
+```
 
 ### 4. リリース実行
 


### PR DESCRIPTION
## Summary

`Prepare Release PR` ワークフローの明示バージョン指定パスが動作していなかったのを修正します。

`release_type` は `auto` / `patch` / `minor` / `major` の選択肢を提供し、選択値をそのまま release-please の `release-as` に渡していました。しかし `release-as` は **正確なバージョン文字列のみ**を受け付けます。

> "manually set next version to be \"1.2.3\" ignoring conventional commits. absence defaults to conventional commits derived next version."
> — [manifest-releaser.md](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)

そのため `auto` 以外を選ぶと `release-as: minor` のような不正値が渡り、明示指定パスは一度も機能していませんでした。v0.7.0 のリリースでは回避策として `Release-As:` コミットフッターを使っています。

## Changes

- `release_type`（choice）を `release_as`（string）に置き換え。空欄ならこれまでどおりconventional commitsから導出
- 冒頭に検証ステップを追加し、semver でない入力を明示的に失敗させる（`minor` などの誤入力が静かに壊れないように）
- `docs/RELEASE.md` の手順を更新し、`Release-As:` フッターによる指定方法も追記

## Test plan

- [x] YAML がパースでき、3ステップの `if` 条件が意図どおりであることを確認
- [x] 検証ロジックの正規表現を確認: `0.8.0` / `1.2.3` / `0.7.1-beta.1` / `1.0.0+build5` は通過、`minor` / `patch` / `major` / `v0.8.0` / `0.8` / `abc` は拒否
- [ ] 次回リリース時に実地確認

> **Note**: `googleapis/release-please-action` の SHA は v4.4.1 のままです。v5.0.0 への更新は #273 で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYC3Ky6epdVtB8sRxeX3PP