### PR TITLE
fix(logger): restore file logging in packaged builds

### DIFF
--- a/src/main/utils/__tests__/logger.test.ts
+++ b/src/main/utils/__tests__/logger.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { isProductionRuntime, resolveLogPath, setElectronApp, clearLoggerCache } from '../logger';
+
+describe('logger', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    clearLoggerCache();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    setElectronApp(null);
+    clearLoggerCache();
+  });
+
+  describe('isProductionRuntime', () => {
+    test('packaged app is production even when NODE_ENV is undefined', () => {
+      // Packaged Electron builds do not set NODE_ENV. This is the case that
+      // silently disabled file logging in released builds.
+      expect(isProductionRuntime({ isPackaged: true }, undefined)).toBe(true);
+    });
+
+    test('unpackaged app is not production when NODE_ENV is undefined', () => {
+      expect(isProductionRuntime({ isPackaged: false }, undefined)).toBe(false);
+    });
+
+    test('test environment is never production even when packaged', () => {
+      expect(isProductionRuntime({ isPackaged: true }, 'test')).toBe(false);
+    });
+
+    test('falls back to NODE_ENV when the Electron app is unavailable', () => {
+      expect(isProductionRuntime(null, 'production')).toBe(true);
+      expect(isProductionRuntime(null, 'development')).toBe(false);
+      expect(isProductionRuntime(null, undefined)).toBe(false);
+    });
+  });
+
+  describe('resolveLogPath', () => {
+    test('uses the Electron userData directory when the app is available', () => {
+      const getPath = vi.fn().mockReturnValue('/tmp/test-userdata');
+      expect(resolveLogPath({ getPath } as never)).toBe('/tmp/test-userdata');
+      expect(getPath).toHaveBeenCalledWith('userData');
+    });
+
+    test('falls back to the temp directory when the app is unavailable', () => {
+      expect(resolveLogPath(null)).toBe(path.join(os.tmpdir(), 'epub-image-extractor-logs'));
+    });
+
+    test('falls back to the temp directory when getPath throws', () => {
+      const getPath = vi.fn().mockImplementation(() => {
+        throw new Error('not ready');
+      });
+      expect(resolveLogPath({ getPath } as never)).toBe(
+        path.join(os.tmpdir(), 'epub-image-extractor-logs'),
+      );
+    });
+  });
+
+  describe('production file output', () => {
+    test('writes log records to app.log in the userData directory', async () => {
+      // Reproduces the packaged-app case: no NODE_ENV, isPackaged true.
+      // pino.transport() would throw "__dirname is not defined" in the ESM
+      // bundle and silently fall back to a transport-less logger, so this
+      // asserts the file is actually written.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'logger-test-'));
+      delete process.env.NODE_ENV;
+
+      setElectronApp({ isPackaged: true, getPath: () => dir } as never);
+      const mod = await import('../logger');
+      mod.logger.error('verification-marker');
+      mod.logger.flush?.();
+
+      await vi.waitFor(() => {
+        const file = path.join(dir, 'app.log');
+        expect(fs.existsSync(file)).toBe(true);
+        expect(fs.readFileSync(file, 'utf8')).toContain('verification-marker');
+      });
+
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+  });
+
+  describe('setElectronApp', () => {
+    test('rebuilds the exported logger so it picks up the injected app', async () => {
+      const mod = await import('../logger');
+      const before = mod.logger;
+
+      setElectronApp({
+        isPackaged: false,
+        getPath: () => os.tmpdir(),
+      } as never);
+
+      // The module-level logger is created at import time, before the Electron
+      // app is injected. Injecting must replace it, otherwise every consumer
+      // keeps a logger built from the wrong environment.
+      expect(mod.logger).not.toBe(before);
+    });
+  });
+});

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -9,16 +9,37 @@ import { AppError } from '../../shared/error-types';
 let electronApp: App | null = null;
 
 // ElectronのappオブジェクトをセットするためのAPI
-export function setElectronApp(app: App): void {
+// ロガーはモジュール読み込み時に一度作られるため、appの注入後に作り直す。
+// export let + ESMのライブバインディングにより、利用側の import も新しい
+// インスタンスを参照する。
+export function setElectronApp(app: App | null): void {
   electronApp = app;
+  clearLoggerCache();
+  logger = createLogger();
+}
+
+// 本番かどうかの判定
+// パッケージ版のElectronは NODE_ENV を設定しないため、appがあれば
+// isPackaged を信頼する。appが無い場合のみ NODE_ENV にフォールバックする。
+export function isProductionRuntime(
+  app: Pick<App, 'isPackaged'> | null,
+  nodeEnv: string | undefined,
+): boolean {
+  if (nodeEnv === 'test') {
+    return false;
+  }
+  if (app) {
+    return app.isPackaged;
+  }
+  return nodeEnv === 'production';
 }
 
 // ログファイルのパスを取得（Electronが利用できない場合は一時ディレクトリを使用）
-function getLogPath(): string {
+export function resolveLogPath(app: Pick<App, 'getPath'> | null): string {
   // セットされたElectronアプリケーションを使用
-  if (electronApp && electronApp.getPath) {
+  if (app && app.getPath) {
     try {
-      return electronApp.getPath('userData');
+      return app.getPath('userData');
     } catch {
       // エラーが発生した場合はフォールバック
     }
@@ -51,24 +72,23 @@ export function createLogger(): pino.Logger {
     return loggerInstance;
   }
 
-  const logPath = getLogPath();
+  const logPath = resolveLogPath(electronApp);
   const logLevel = process.env.LOG_LEVEL || (process.env.NODE_ENV === 'test' ? 'error' : 'info');
-  const isDevelopment = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+  const isProduction = isProductionRuntime(electronApp, process.env.NODE_ENV);
+  const isDevelopment = !isProduction && process.env.NODE_ENV !== 'test';
   const isTest = process.env.NODE_ENV === 'test';
 
-  // テスト環境：トランスポートなし、開発環境：コンソール出力、本番環境：ファイル出力
-  const transport =
+  // テスト環境：出力先なし、開発環境：コンソール出力、本番環境：ファイル出力
+  // pino.transport() はワーカースレッド内で __dirname を使うため ESM バンドルでは
+  // 動作しない。ワーカーを使わない pino.destination() でファイルに書き出す。
+  // sync: true にしないとバッファされ、クラッシュ時に直前のログが失われる。
+  // 出力は warn/error のみで量が少ないため同期書き込みで問題ない。
+  const destination =
     isTest || isDevelopment
       ? undefined
-      : {
-          target: 'pino/file',
-          options: {
-            destination: path.join(logPath, 'app.log'),
-            mkdir: true,
-          },
-        };
+      : pino.destination({ dest: path.join(logPath, 'app.log'), mkdir: true, sync: true });
 
-  const pinoOptions: pino.LoggerOptions & { transport?: pino.TransportSingleOptions } = {
+  const pinoOptions: pino.LoggerOptions = {
     level: logLevel,
     timestamp: pino.stdTimeFunctions.isoTime,
     // 開発環境では人間が読みやすい形式に
@@ -105,13 +125,8 @@ export function createLogger(): pino.Logger {
     },
   };
 
-  // トランスポートがある場合のみ追加
-  if (transport) {
-    pinoOptions.transport = transport;
-  }
-
   try {
-    loggerInstance = pino(pinoOptions);
+    loggerInstance = destination ? pino(pinoOptions, destination) : pino(pinoOptions);
   } catch (error) {
     console.error('[Logger] Failed to create pino instance:', error);
     // フォールバック: 最小限のロガーを作成
@@ -124,7 +139,8 @@ export function createLogger(): pino.Logger {
 }
 
 // デフォルトロガーのエクスポート
-export const logger = createLogger();
+// setElectronApp() で差し替わるため const ではなく let
+export let logger = createLogger();
 
 // getLogger関数（後方互換性のため）
 export function getLogger(): pino.Logger {


### PR DESCRIPTION
## Summary

`docs/LOGGING.md` は本番環境で `userData/app.log` に JSON 形式で出力すると規定していますが、リリース版では**ログファイルが一切作られていませんでした**。3つの不具合が重なっていました。

1. **`NODE_ENV` による本番判定** — パッケージ版の Electron は `NODE_ENV` を設定しないため、常に「開発環境」と判定され、ファイル出力の分岐に入りませんでした → `app.isPackaged` で判定
2. **ロガーの生成タイミング** — `export const logger = createLogger()` はモジュール読み込み時に走りますが、`setElectronApp(app)` は `index.ts` の `whenReady` 内です。生成時点で app が未注入のため、パスが `userData` ではなく一時ディレクトリに解決されていました → 注入時に作り直し、ESMのライブバインディングで既存の import 側にも反映
3. **`pino.transport()` が ESM バンドルで動作しない** — ワーカー内で `__dirname` を参照し `ReferenceError` を投げます。これが catch されてトランスポート無しのロガーにフォールバックしており、失敗が隠れていました → ワーカーを使わない `pino.destination()` に変更

1と2だけを直しても3が残るためログは出ないままでした。パッケージ版で実際に確認して初めて露出しました。

```
[Logger] Failed to create pino instance: ReferenceError: __dirname is not defined
```

また `pino.destination()` は既定でバッファリングされ、クラッシュ時に直前のログが失われます。診断が目的なので `sync: true` にしています。出力対象は warn/error のみで量が少なく、同期書き込みの影響は無視できます。

## 出力されるログの範囲

デフォルトレベル `info` で実際にファイルに書かれるのは **warn(10箇所) と error(9箇所) のみ**です。`info` の呼び出しは0件、`debug` の24件はレベル未満で抑制されます。

## Test plan

- [x] `pnpm dist:mac-arm64` でパッケージし、起動して `~/Library/Application Support/EPUB Image Extractor/app.log` が作られることを確認（修正前は作られず）
- [x] 同じ起動で `Failed to create pino instance` が出ないことを確認（修正前は発生）
- [x] 実ファイルへの書き込み・読み出しを検証するテストを追加（ロガーのテストはこれまで0件でした）
- [x] `pnpm test` 420件通過 / `typecheck` / `lint` / `format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYC3Ky6epdVtB8sRxeX3PP