### PR TITLE
fix(ci): publish releases only after the assets are attached

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -85,8 +85,9 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        # 作成されたタグをチェックアウト
-        ref: ${{ needs.create-release.outputs.tag_name }}
+        # リリースはdraftで作られるため、この時点ではタグがまだ存在しない。
+        # ワークフローを起動したコミット（Release PRをマージした main）を使う。
+        ref: ${{ github.sha }}
 
     - name: Setup pnpm
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -214,9 +215,19 @@ jobs:
       uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
         tag_name: ${{ needs.create-release.outputs.tag_name }}
+        draft: true
         files: |
           release-artifacts/macos-latest-x64-build/*
           release-artifacts/macos-latest-arm64-build/*
           release-artifacts/windows-latest-x64-build/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # ここで初めてリリースが公開され、タグが作成される。
+    # これより前は draft なので /releases/latest には現れず、
+    # 成果物のない状態でアップデート通知が飛ぶことがない。
+    - name: Publish the release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG_NAME: ${{ needs.create-release.outputs.tag_name }}
+      run: gh release edit "$TAG_NAME" --draft=false

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -165,14 +165,24 @@ git commit --allow-empty -m "chore: release 0.8.0" -m "Release-As: 0.8.0"
 
 実行されると：
 1. **マージされたRelease PRの検証**: 24時間以内にマージされたRelease PRを確認
-2. **タグ作成**: `v0.4.1`のようなタグが自動作成
-3. **GitHub Release作成**: リリースノートとともに公開
-4. **ビルド実行**: 各プラットフォーム向けにビルド
+2. **GitHub Release作成（draft）**: リリースノートとともに**下書き**として作成
+3. **ビルド実行**: 各プラットフォーム向けにビルド
    - macOS: `EPUB-Image-Extractor-{version}-arm64.dmg`
    - macOS: `EPUB-Image-Extractor-{version}-x64.dmg`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Setup.exe`
    - Windows: `EPUB-Image-Extractor-{version}-x64-Portable.exe`
-5. **成果物アップロード**: ビルド成果物をGitHub Releaseに自動追加
+4. **成果物アップロード**: ビルド成果物をdraftリリースに追加
+5. **リリース公開**: draftを解除。**このタイミングで初めてタグが作成され、リリースが公開される**
+
+> **なぜdraftを経由するのか**
+>
+> 以前はリリースが先に公開され、成果物の添付は10〜15分後でした。その間 GitHub API の
+> `/releases/latest` は新バージョンを返すため、アプリのアップデート通知を見たユーザーが
+> 「GitHubで見る」を押すと、ダウンロードできるファイルが無いページに到達していました。
+>
+> draftリリースは `/releases/latest` から除外されるため、成果物が揃うまでアップデート
+> 通知は発生しません。なお**draftの間はタグが作成されない**ので、ビルドジョブは
+> タグではなくワークフローを起動したコミット（`github.sha`）をチェックアウトします。
 
 ## 🛠 メンテナンス作業
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tags": true,
   "draft-pull-request": true,
+  "draft": true,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

リリースが公開されてから成果物が添付されるまで **10〜15分の窓** があり、その間 `/releases/latest` は新バージョンを返すのにダウンロードできるファイルがありませんでした。アプリのアップデート通知は「GitHubで見る」でこのページに誘導するため、**ユーザーは空のリリースページに到達していました**。v0.7.0 のリリースで実際に発生しています。

リリースを **draft で作成し、成果物の添付が終わってから公開**します。draft リリースは `/releases/latest` から除外されるため、ダウンロード可能になるまでアップデート確認に現れません。

## 実測して確認したこと

APIで一時的なdraftリリースを作成して検証しました（作成後すぐ削除済み）。

| 確認項目 | 結果 |
|---|---|
| draftリリースはタグを作るか | **作らない**（`git ls-remote --tags` で0件） |
| `gh` はdraftをタグ名で解決できるか | **できる**（`gh release view <tag>` が `isDraft: true` を返す） |

そのため `build-and-release` はタグをチェックアウトできません。ワークフローを起動したコミット（`github.sha` = Release PR をマージした main）をチェックアウトするよう変更しています。

## Changes

- `release-please-config.json`: `"draft": true`
- `publish-github-release.yml`:
  - `build-and-release` の checkout を `tag_name` → `github.sha`
  - `Upload release assets` に `draft: true`（アクションが誤ってdraftを解除しないように）
  - 最後に `gh release edit "$TAG" --draft=false` で公開。**このタイミングでタグが作成される**
- `docs/RELEASE.md`: 手順と理由を更新

## Test plan

- [x] draftとタグの挙動をGitHub APIで実測（上表）
- [x] ワークフローYAMLのパースとジョブ依存関係を確認
- [ ] **次回リリース時に実地確認** — `create-release` が draft でも `release_created: true` を出力すること、`gh release upload` がdraftに添付できること

> **Note**: ワークフローの変更は次のリリースまで実地検証できません。失敗した場合もリリースはdraftのまま（タグ未作成）なので、公開されずに済みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYC3Ky6epdVtB8sRxeX3PP