### PR TITLE
ci: run the dependency audit as its own job

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,8 +18,12 @@ permissions:
   contents: read
 
 jobs:
-  # Stage 1: Quick validation on Ubuntu (5-7 minutes)
-  quick-validation:
+  # Dependency audit runs on its own so a newly published advisory only fails
+  # this job. It used to be a step inside quick-validation, which is the
+  # required check, so a single advisory in a production dependency blocked
+  # every open PR - including the dependency updates that would have fixed it.
+  # Keep this out of the required checks; it is a signal, not a gate.
+  dependency-audit:
     runs-on: ubuntu-latest
 
     steps:
@@ -39,6 +43,25 @@ jobs:
 
     - name: Audit dependencies for known vulnerabilities
       run: pnpm audit --prod --audit-level=high
+
+  # Stage 1: Quick validation on Ubuntu (5-7 minutes)
+  quick-validation:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: Setup Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: '24'
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
 
     - name: Run Prettier format check
       run: pnpm format:check


### PR DESCRIPTION
## Summary

`pnpm audit --prod --audit-level=high` は必須チェックである `quick-validation` の**中のステップ**でした。そのため**本番依存に新しい脆弱性が1件公表されるだけで、無関係なものを含む全PRのCIが落ちます**。

実際にこれが起きました。`fast-xml-builder` の advisory により **12本のPRが3ヶ月滞留**し、その間セキュリティ更新も一切マージできませんでした。皮肉なことに、**セキュリティゲートがセキュリティ更新を止めていました**。

auditを `dependency-audit` ジョブとして分離します。脆弱性が出てもそのジョブだけが赤くなり、可視性は保ったまま無関係な作業を止めません。

## 必須チェックの設定について

**このPRのマージ後、`dependency-audit` を必須チェックに追加しないでください。** 追加すると元の問題が再発します。ワークフロー内にもコメントで残しています。

現在の ruleset の必須チェックは `quick-validation` のみで、変更は不要です。

## トレードオフ

脆弱性のある状態でもマージ可能になります。ただし今回の実害（3ヶ月・12PR滞留、セキュリティ更新の停止）がゲートの利益を明確に上回っていると判断しました。auditジョブは赤く表示されるため見落としにはなりません。

`main-validation.yml` 側の audit はそのままです（mainの状態を示すシグナルとして機能させる）。

## Test plan

- [x] YAMLのパースとジョブ構成を確認（`dependency-audit` / `quick-validation` / `platform-e2e`）
- [x] `quick-validation` から audit ステップが除かれていることを確認
- [ ] このPR自身のCIで両ジョブが独立して動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYC3Ky6epdVtB8sRxeX3PP