### PR TITLE
fix(ci): stop the publish workflow from opening a release PR

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -62,7 +62,12 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # skip-github-releaseを指定しない（リリースを作成する）
+          # This workflow only tags and releases; prepare-release-pr.yml owns
+          # pull request creation. Without skip-github-pull-request the action
+          # also opens a release PR here, and because the release is still a
+          # draft its tag does not exist yet, so it reads the previous release
+          # as current and proposes rolling the version back.
+          skip-github-pull-request: true
 
   build-and-release:
     needs: create-release


### PR DESCRIPTION
## Summary

Publishing v0.7.1 produced an unwanted `chore(main): release 0.7.0` pull request (#309) that would have **rolled the version back from 0.7.1 to 0.7.0 and regenerated the entire changelog from the start of history**. It was closed manually.

## Root cause

The release-please step in `publish-github-release.yml` creates both the GitHub Release **and** a release pull request. Since #305 made releases drafts, the tag no longer exists while the workflow runs — draft releases do not create their tag until published. release-please therefore read `v0.7.0` as the latest release and proposed a release PR based on that stale state.

The timing confirms it: `create-release` ran 04:48:10–04:49:37, and #309 was created at 04:49:34, while the v0.7.1 release was still a draft (published at 04:52:22).

This was latent before #305 — the tag used to exist immediately, so the PR logic saw consistent state.

## Fix

Pass `skip-github-pull-request: true` so this workflow only tags and releases.

> "If `true`, do not attempt to create release pull requests. This is useful if splitting release tagging from PR creation."
> — [release-please-action README](https://github.com/googleapis/release-please-action)

`prepare-release-pr.yml` already owns pull request creation via `skip-github-release: true`, so the two workflows are now symmetric: one makes the PR, the other makes the release.

## Test plan

- [x] Workflow YAML parses and the step receives `skip-github-pull-request: true`
- [x] Confirmed `prepare-release-pr.yml` still carries `skip-github-release: true` on both of its steps
- [ ] Verify at the next release that no stray release PR appears

> **Note**: the draft flow itself worked correctly in v0.7.1 — `created_at` 04:47:56 and `published_at` 04:52:22 are 4m26s apart, so the release stayed invisible to `/releases/latest` until its assets were attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYC3Ky6epdVtB8sRxeX3PP